### PR TITLE
[MM-21691] Handle errors for getSchedule call

### DIFF
--- a/server/remote/msgraph/get_schedule_batched.go
+++ b/server/remote/msgraph/get_schedule_batched.go
@@ -1,6 +1,7 @@
 package msgraph
 
 import (
+	"errors"
 	"strconv"
 
 	"github.com/mattermost/mattermost-plugin-mscalendar/server/remote"
@@ -8,8 +9,14 @@ import (
 
 const maxNumUsersPerRequest = 20
 
+type apiError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
 type getScheduleResponse struct {
 	Value []*remote.ScheduleInformation `json:"value,omitempty"`
+	Error *apiError
 }
 
 type getScheduleSingleResponse struct {
@@ -73,6 +80,9 @@ func (c *client) GetSchedule(remoteUserID string, schedules []string, startTime,
 		sorted := make([]*getScheduleSingleResponse, length)
 
 		for _, res := range batchRes.Responses {
+			if res.Body.Error != nil {
+				return nil, errors.New(res.Body.Error.Message)
+			}
 			id, _ := strconv.Atoi(res.ID)
 			sorted[id] = res
 		}


### PR DESCRIPTION
#### Summary

This PR takes into account when a Graph API error occurs with an individual call inside of the batch call for `getSchedule`. If there is an error with any of them, the operation bails and no user statuses get updated. The way the caller is set up, it should be fairly trivial to change the code to simply "skip over" the ones that had errors if we wish to do it that way.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-21691
