### PR TITLE
WIP: [MM-22457] Delta links used in case of notification outage

### DIFF
--- a/server/mscalendar/filters.go
+++ b/server/mscalendar/filters.go
@@ -25,6 +25,18 @@ func withUserExpanded(user *User) func(m *mscalendar) error {
 	}
 }
 
+func withRemoteUser(user *User) func(m *mscalendar) error {
+	return func(m *mscalendar) error {
+		return m.ExpandRemoteUser(user)
+	}
+}
+
+func withMattermostUser(user *User) func(m *mscalendar) error {
+	return func(m *mscalendar) error {
+		return m.ExpandMattermostUser(user)
+	}
+}
+
 func withClient(m *mscalendar) error {
 	if m.client != nil {
 		return nil

--- a/server/mscalendar/mock_mscalendar/mock_mscalendar.go
+++ b/server/mscalendar/mock_mscalendar/mock_mscalendar.go
@@ -254,6 +254,22 @@ func (mr *MockMSCalendarMockRecorder) GetTimezone(arg0 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTimezone", reflect.TypeOf((*MockMSCalendar)(nil).GetTimezone), arg0)
 }
 
+// InitEventDelta mocks base method
+func (m *MockMSCalendar) InitEventDelta(arg0 *mscalendar.User) ([]*remote.Event, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InitEventDelta", arg0)
+	ret0, _ := ret[0].([]*remote.Event)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// InitEventDelta indicates an expected call of InitEventDelta
+func (mr *MockMSCalendarMockRecorder) InitEventDelta(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitEventDelta", reflect.TypeOf((*MockMSCalendar)(nil).InitEventDelta), arg0)
+}
+
 // IsAuthorizedAdmin mocks base method
 func (m *MockMSCalendar) IsAuthorizedAdmin(arg0 string) (bool, error) {
 	m.ctrl.T.Helper()
@@ -326,6 +342,22 @@ func (m *MockMSCalendar) RespondToEvent(arg0 *mscalendar.User, arg1, arg2 string
 func (mr *MockMSCalendarMockRecorder) RespondToEvent(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RespondToEvent", reflect.TypeOf((*MockMSCalendar)(nil).RespondToEvent), arg0, arg1, arg2)
+}
+
+// RollingEventDelta mocks base method
+func (m *MockMSCalendar) RollingEventDelta(arg0 *mscalendar.User) ([]*remote.Event, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RollingEventDelta", arg0)
+	ret0, _ := ret[0].([]*remote.Event)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// RollingEventDelta indicates an expected call of RollingEventDelta
+func (mr *MockMSCalendarMockRecorder) RollingEventDelta(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RollingEventDelta", reflect.TypeOf((*MockMSCalendar)(nil).RollingEventDelta), arg0)
 }
 
 // SyncStatus mocks base method

--- a/server/mscalendar/mock_mscalendar/mock_mscalendar.go
+++ b/server/mscalendar/mock_mscalendar/mock_mscalendar.go
@@ -254,20 +254,20 @@ func (mr *MockMSCalendarMockRecorder) GetTimezone(arg0 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTimezone", reflect.TypeOf((*MockMSCalendar)(nil).GetTimezone), arg0)
 }
 
-// InitEventDelta mocks base method
-func (m *MockMSCalendar) InitEventDelta(arg0 *mscalendar.User) ([]*remote.Event, string, error) {
+// InitPolling mocks base method
+func (m *MockMSCalendar) InitPolling(arg0 *mscalendar.User) ([]*remote.Event, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InitEventDelta", arg0)
+	ret := m.ctrl.Call(m, "InitPolling", arg0)
 	ret0, _ := ret[0].([]*remote.Event)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
-// InitEventDelta indicates an expected call of InitEventDelta
-func (mr *MockMSCalendarMockRecorder) InitEventDelta(arg0 interface{}) *gomock.Call {
+// InitPolling indicates an expected call of InitPolling
+func (mr *MockMSCalendarMockRecorder) InitPolling(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitEventDelta", reflect.TypeOf((*MockMSCalendar)(nil).InitEventDelta), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitPolling", reflect.TypeOf((*MockMSCalendar)(nil).InitPolling), arg0)
 }
 
 // IsAuthorizedAdmin mocks base method
@@ -315,6 +315,22 @@ func (mr *MockMSCalendarMockRecorder) LoadMyEventSubscription() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadMyEventSubscription", reflect.TypeOf((*MockMSCalendar)(nil).LoadMyEventSubscription))
 }
 
+// Poll mocks base method
+func (m *MockMSCalendar) Poll(arg0 *mscalendar.User) ([]*remote.Event, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Poll", arg0)
+	ret0, _ := ret[0].([]*remote.Event)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// Poll indicates an expected call of Poll
+func (mr *MockMSCalendarMockRecorder) Poll(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Poll", reflect.TypeOf((*MockMSCalendar)(nil).Poll), arg0)
+}
+
 // RenewMyEventSubscription mocks base method
 func (m *MockMSCalendar) RenewMyEventSubscription() (*store.Subscription, error) {
 	m.ctrl.T.Helper()
@@ -342,22 +358,6 @@ func (m *MockMSCalendar) RespondToEvent(arg0 *mscalendar.User, arg1, arg2 string
 func (mr *MockMSCalendarMockRecorder) RespondToEvent(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RespondToEvent", reflect.TypeOf((*MockMSCalendar)(nil).RespondToEvent), arg0, arg1, arg2)
-}
-
-// RollingEventDelta mocks base method
-func (m *MockMSCalendar) RollingEventDelta(arg0 *mscalendar.User) ([]*remote.Event, string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RollingEventDelta", arg0)
-	ret0, _ := ret[0].([]*remote.Event)
-	ret1, _ := ret[1].(string)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// RollingEventDelta indicates an expected call of RollingEventDelta
-func (mr *MockMSCalendarMockRecorder) RollingEventDelta(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RollingEventDelta", reflect.TypeOf((*MockMSCalendar)(nil).RollingEventDelta), arg0)
 }
 
 // SyncStatus mocks base method

--- a/server/mscalendar/mscalendar.go
+++ b/server/mscalendar/mscalendar.go
@@ -22,12 +22,13 @@ type MSCalendar interface {
 
 // Dependencies contains all API dependencies
 type Dependencies struct {
-	Logger            bot.Logger
-	PluginAPI         PluginAPI
-	Poster            bot.Poster
-	Remote            remote.Remote
-	Store             store.Store
-	IsAuthorizedAdmin func(string) (bool, error)
+	Logger                bot.Logger
+	PluginAPI             PluginAPI
+	Poster                bot.Poster
+	Remote                remote.Remote
+	Store                 store.Store
+	NotificationProcessor NotificationProcessor
+	IsAuthorizedAdmin     func(string) (bool, error)
 }
 
 type PluginAPI interface {

--- a/server/mscalendar/notification.go
+++ b/server/mscalendar/notification.go
@@ -172,8 +172,7 @@ func (processor *notificationProcessor) processNotification(n *remote.Notificati
 	if prior != nil {
 		if n.ChangeType == "deleted" {
 			n.Event = prior.Remote
-			sa = processor.newEventSlackAttachment(n)
-			sa.Title = "(deleted) " + sa.Title
+			sa = processor.deletedEventSlackAttachment(n)
 		} else {
 			var changed bool
 			changed, sa = processor.updatedEventSlackAttachment(n, prior.Remote)
@@ -219,6 +218,12 @@ func (processor *notificationProcessor) newSlackAttachment(n *remote.Notificatio
 		Title:      n.Event.Subject,
 		Text:       n.Event.BodyPreview,
 	}
+}
+
+func (processor *notificationProcessor) deletedEventSlackAttachment(n *remote.Notification) *model.SlackAttachment {
+	sa := processor.newEventSlackAttachment(n)
+	sa.Title = "(deleted) " + sa.Title[6:]
+	return sa
 }
 
 func (processor *notificationProcessor) newEventSlackAttachment(n *remote.Notification) *model.SlackAttachment {

--- a/server/mscalendar/notification.go
+++ b/server/mscalendar/notification.go
@@ -170,16 +170,22 @@ func (processor *notificationProcessor) processNotification(n *remote.Notificati
 		return err
 	}
 	if prior != nil {
-		var changed bool
-		changed, sa = processor.updatedEventSlackAttachment(n, prior.Remote)
-		if !changed {
-			processor.Logger.With(bot.LogContext{
-				"MattermostUserID": creator.MattermostUserID,
-				"SubsriptionID":    n.SubscriptionID,
-				"ChangeType":       n.ChangeType,
-				"EventID":          n.Event.ID,
-			}).Debugf("webhook notification: no changes detected in event.")
-			return nil
+		if n.ChangeType == "deleted" {
+			n.Event = prior.Remote
+			sa = processor.newEventSlackAttachment(n)
+			sa.Title = "(deleted) " + sa.Title
+		} else {
+			var changed bool
+			changed, sa = processor.updatedEventSlackAttachment(n, prior.Remote)
+			if !changed {
+				processor.Logger.With(bot.LogContext{
+					"MattermostUserID": creator.MattermostUserID,
+					"SubsriptionID":    n.SubscriptionID,
+					"ChangeType":       n.ChangeType,
+					"EventID":          n.Event.ID,
+				}).Debugf("webhook notification: no changes detected in event.")
+				return nil
+			}
 		}
 	} else {
 		sa = processor.newEventSlackAttachment(n)

--- a/server/mscalendar/subscription.go
+++ b/server/mscalendar/subscription.go
@@ -57,6 +57,20 @@ func (m *mscalendar) LoadMyEventSubscription() (*store.Subscription, error) {
 	return storedSub, err
 }
 
+func (m *mscalendar) loadUserSubscription(mattermostUserID string) (*store.Subscription, error) {
+	user, err := m.Store.LoadUser(mattermostUserID)
+	if err != nil {
+		return nil, err
+	}
+
+	subID := user.Settings.EventSubscriptionID
+	if subID == "" {
+		return nil, errors.New("No subscription stored for " + user.Remote.Mail)
+	}
+
+	return m.Store.LoadSubscription(subID)
+}
+
 func (m *mscalendar) ListRemoteSubscriptions() ([]*remote.Subscription, error) {
 	err := m.Filter(withClient)
 	if err != nil {

--- a/server/mscalendar/user.go
+++ b/server/mscalendar/user.go
@@ -44,6 +44,18 @@ func (m *mscalendar) GetActingUser() *User {
 }
 
 func (m *mscalendar) ExpandUser(user *User) error {
+	err := m.ExpandRemoteUser(user)
+	if err != nil {
+		return err
+	}
+	err = m.ExpandMattermostUser(user)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *mscalendar) ExpandRemoteUser(user *User) error {
 	if user.User == nil {
 		storedUser, err := m.Store.LoadUser(user.MattermostUserID)
 		if err != nil {
@@ -51,6 +63,10 @@ func (m *mscalendar) ExpandUser(user *User) error {
 		}
 		user.User = storedUser
 	}
+	return nil
+}
+
+func (m *mscalendar) ExpandMattermostUser(user *User) error {
 	if user.MattermostUser == nil {
 		mattermostUser, err := m.PluginAPI.GetMattermostUser(user.MattermostUserID)
 		if err != nil {

--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -32,11 +32,10 @@ import (
 
 type Env struct {
 	mscalendar.Env
-	bot                   bot.Bot
-	statusSyncJob         *mscalendar.StatusSyncJob
-	notificationProcessor mscalendar.NotificationProcessor
-	httpHandler           *httputils.Handler
-	configError           error
+	bot           bot.Bot
+	statusSyncJob *mscalendar.StatusSyncJob
+	httpHandler   *httputils.Handler
+	configError   error
 }
 
 type Plugin struct {
@@ -120,15 +119,15 @@ func (p *Plugin) OnConfigurationChange() (err error) {
 		e.Dependencies.Store = store.NewPluginStore(p.API, e.bot)
 		e.Dependencies.IsAuthorizedAdmin = p.IsAuthorizedAdmin
 
-		if e.notificationProcessor == nil {
-			e.notificationProcessor = mscalendar.NewNotificationProcessor(e.Env)
+		if e.Env.NotificationProcessor == nil {
+			e.Env.NotificationProcessor = mscalendar.NewNotificationProcessor(e.Env)
 		} else {
-			e.notificationProcessor.Configure(e.Env)
+			e.Env.NotificationProcessor.Configure(e.Env)
 		}
 
 		e.httpHandler = httputils.NewHandler()
 		oauth2connect.Init(e.httpHandler, mscalendar.NewOAuth2App(e.Env))
-		api.Init(e.httpHandler, e.Env, e.notificationProcessor)
+		api.Init(e.httpHandler, e.Env, e.Env.NotificationProcessor)
 
 		// POC_initUserStatusSyncJob begins a job that runs every 5 minutes to update the MM user's status based on their status in their Microsoft calendar
 		// This needs to be improved to run on a single node in the HA environment. Hence why the name is currently prefixed with POC

--- a/server/remote/client.go
+++ b/server/remote/client.go
@@ -30,4 +30,6 @@ type Client interface {
 	RenewSubscription(subscriptionID string) (*Subscription, error)
 	TentativelyAcceptEvent(remoteUserID, eventID string) error
 	GetSuperuserToken() (string, error)
+	GetEventDeltaFromDateRange(remoteUserID string, start, end *DateTime) (events []*Event, deltaLink string, err error)
+	GetEventDeltaFromURL(deltaURL string) (events []*Event, deltaLink string, err error)
 }

--- a/server/remote/mock_remote/mock_client.go
+++ b/server/remote/mock_remote/mock_client.go
@@ -226,6 +226,38 @@ func (mr *MockClientMockRecorder) GetEvent(arg0, arg1 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEvent", reflect.TypeOf((*MockClient)(nil).GetEvent), arg0, arg1)
 }
 
+// GetEventDeltaFromDateRange mocks base method
+func (m *MockClient) GetEventDeltaFromDateRange(arg0 string, arg1, arg2 *remote.DateTime) ([]*remote.Event, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEventDeltaFromDateRange", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]*remote.Event)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetEventDeltaFromDateRange indicates an expected call of GetEventDeltaFromDateRange
+func (mr *MockClientMockRecorder) GetEventDeltaFromDateRange(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEventDeltaFromDateRange", reflect.TypeOf((*MockClient)(nil).GetEventDeltaFromDateRange), arg0, arg1, arg2)
+}
+
+// GetEventDeltaFromURL mocks base method
+func (m *MockClient) GetEventDeltaFromURL(arg0 string) ([]*remote.Event, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEventDeltaFromURL", arg0)
+	ret0, _ := ret[0].([]*remote.Event)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetEventDeltaFromURL indicates an expected call of GetEventDeltaFromURL
+func (mr *MockClientMockRecorder) GetEventDeltaFromURL(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEventDeltaFromURL", reflect.TypeOf((*MockClient)(nil).GetEventDeltaFromURL), arg0)
+}
+
 // GetMailboxSettings mocks base method
 func (m *MockClient) GetMailboxSettings(arg0 string) (*remote.MailboxSettings, error) {
 	m.ctrl.T.Helper()

--- a/server/remote/msgraph/get_event_delta.go
+++ b/server/remote/msgraph/get_event_delta.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See License for license information.
+
+package msgraph
+
+import (
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/mattermost/mattermost-plugin-mscalendar/server/remote"
+)
+
+type getEventDeltaResponse struct {
+	NextLink  string          `json:"@odata.nextLink"`
+	DeltaLink string          `json:"@odata.deltaLink"`
+	Value     []*remote.Event `json:"value"`
+}
+
+func (c *client) GetEventDeltaFromDateRange(remoteUserID string, start, end *remote.DateTime) (events []*remote.Event, deltaLink string, err error) {
+	q := url.Values{}
+	q.Add("StartDateTime", start.Time().Format(time.RFC3339))
+	q.Add("EndDateTime", end.Time().Format(time.RFC3339))
+	params := "?" + q.Encode()
+
+	u := c.rbuilder.Me().CalendarView().URL() + "/delta" + params
+	var out getEventDeltaResponse
+
+	_, err = c.CallJSON(http.MethodGet, u, nil, &out)
+	if err != nil {
+		return nil, "", err
+	}
+
+	ls := []*remote.Event{}
+	ls = append(ls, out.Value...)
+
+	nextLink := out.NextLink
+	for nextLink != "" {
+		out = getEventDeltaResponse{}
+
+		_, err = c.CallJSON(http.MethodGet, nextLink, nil, &out)
+		if err != nil {
+			return nil, "", err
+		}
+
+		ls = append(ls, out.Value...)
+		nextLink = out.NextLink
+	}
+
+	return ls, out.DeltaLink, nil
+}
+
+func (c *client) GetEventDeltaFromURL(deltaURL string) (events []*remote.Event, deltaLink string, err error) {
+	var out getEventDeltaResponse
+
+	_, err = c.CallJSON(http.MethodGet, deltaURL, nil, &out)
+	if err != nil {
+		return nil, "", err
+	}
+
+	ls := []*remote.Event{}
+	ls = append(ls, out.Value...)
+
+	nextLink := out.NextLink
+	for nextLink != "" {
+		out = getEventDeltaResponse{}
+
+		_, err = c.CallJSON(http.MethodGet, nextLink, nil, &out)
+		if err != nil {
+			return nil, "", err
+		}
+
+		ls = append(ls, out.Value...)
+		nextLink = out.NextLink
+	}
+
+	return ls, out.DeltaLink, nil
+}

--- a/server/remote/msgraph/get_event_delta.go
+++ b/server/remote/msgraph/get_event_delta.go
@@ -24,42 +24,18 @@ func (c *client) GetEventDeltaFromDateRange(remoteUserID string, start, end *rem
 	params := "?" + q.Encode()
 
 	u := c.rbuilder.Me().CalendarView().URL() + "/delta" + params
-	var out getEventDeltaResponse
-
-	_, err = c.CallJSON(http.MethodGet, u, nil, &out)
-	if err != nil {
-		return nil, "", err
-	}
-
-	ls := []*remote.Event{}
-	ls = append(ls, out.Value...)
-
-	nextLink := out.NextLink
-	for nextLink != "" {
-		out = getEventDeltaResponse{}
-
-		_, err = c.CallJSON(http.MethodGet, nextLink, nil, &out)
-		if err != nil {
-			return nil, "", err
-		}
-
-		ls = append(ls, out.Value...)
-		nextLink = out.NextLink
-	}
-
-	return ls, out.DeltaLink, nil
+	return c.GetEventDeltaFromURL(u)
 }
 
 func (c *client) GetEventDeltaFromURL(deltaURL string) (events []*remote.Event, deltaLink string, err error) {
 	var out getEventDeltaResponse
-
 	_, err = c.CallJSON(http.MethodGet, deltaURL, nil, &out)
 	if err != nil {
 		return nil, "", err
 	}
 
-	ls := []*remote.Event{}
-	ls = append(ls, out.Value...)
+	events = []*remote.Event{}
+	events = append(events, out.Value...)
 
 	nextLink := out.NextLink
 	for nextLink != "" {
@@ -70,9 +46,9 @@ func (c *client) GetEventDeltaFromURL(deltaURL string) (events []*remote.Event, 
 			return nil, "", err
 		}
 
-		ls = append(ls, out.Value...)
+		events = append(events, out.Value...)
 		nextLink = out.NextLink
 	}
 
-	return ls, out.DeltaLink, nil
+	return events, out.DeltaLink, nil
 }

--- a/server/store/mock_store/mock_store.go
+++ b/server/store/mock_store/mock_store.go
@@ -150,21 +150,6 @@ func (mr *MockStoreMockRecorder) LoadUserIndex() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadUserIndex", reflect.TypeOf((*MockStore)(nil).LoadUserIndex))
 }
 
-// LoadUserSubscription mocks base method
-func (m *MockStore) LoadUserSubscription(arg0 string) (*store.Subscription, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LoadUserSubscription", arg0)
-	ret0, _ := ret[0].(*store.Subscription)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// LoadUserSubscription indicates an expected call of LoadUserSubscription
-func (mr *MockStoreMockRecorder) LoadUserSubscription(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadUserSubscription", reflect.TypeOf((*MockStore)(nil).LoadUserSubscription), arg0)
-}
-
 // StoreOAuth2State mocks base method
 func (m *MockStore) StoreOAuth2State(arg0 string) error {
 	m.ctrl.T.Helper()

--- a/server/store/mock_store/mock_store.go
+++ b/server/store/mock_store/mock_store.go
@@ -150,6 +150,21 @@ func (mr *MockStoreMockRecorder) LoadUserIndex() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadUserIndex", reflect.TypeOf((*MockStore)(nil).LoadUserIndex))
 }
 
+// LoadUserSubscription mocks base method
+func (m *MockStore) LoadUserSubscription(arg0 string) (*store.Subscription, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LoadUserSubscription", arg0)
+	ret0, _ := ret[0].(*store.Subscription)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LoadUserSubscription indicates an expected call of LoadUserSubscription
+func (mr *MockStoreMockRecorder) LoadUserSubscription(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadUserSubscription", reflect.TypeOf((*MockStore)(nil).LoadUserSubscription), arg0)
+}
+
 // StoreOAuth2State mocks base method
 func (m *MockStore) StoreOAuth2State(arg0 string) error {
 	m.ctrl.T.Helper()

--- a/server/store/subscription_store.go
+++ b/server/store/subscription_store.go
@@ -13,7 +13,6 @@ import (
 
 type SubscriptionStore interface {
 	LoadSubscription(subscriptionID string) (*Subscription, error)
-	LoadUserSubscription(mattermostUserID string) (*Subscription, error)
 	StoreUserSubscription(user *User, subscription *Subscription) error
 	DeleteUserSubscription(user *User, subscriptionID string) error
 }
@@ -22,7 +21,7 @@ type Subscription struct {
 	PluginVersion       string
 	Remote              *remote.Subscription
 	MattermostCreatorID string
-	DeltaURL            string
+	PollingURL          string
 }
 
 func (s *pluginStore) LoadSubscription(subscriptionID string) (*Subscription, error) {
@@ -32,20 +31,6 @@ func (s *pluginStore) LoadSubscription(subscriptionID string) (*Subscription, er
 		return nil, err
 	}
 	return &sub, nil
-}
-
-func (s *pluginStore) LoadUserSubscription(mattermostUserID string) (*Subscription, error) {
-	user, err := s.LoadUser(mattermostUserID)
-	if err != nil {
-		return nil, err
-	}
-
-	subID := user.Settings.EventSubscriptionID
-	if subID == "" {
-		return nil, errors.New("No subscription stored for " + user.Remote.Mail)
-	}
-
-	return s.LoadSubscription(subID)
 }
 
 func (s *pluginStore) StoreUserSubscription(user *User, subscription *Subscription) error {


### PR DESCRIPTION
#### Summary

Microsoft Graph's notification system has experienced outages, so we need a second solution that involves pulling. Using Graph's [Event Delta](https://docs.microsoft.com/en-us/graph/delta-query-events) queries, we can fetch only the events that have changed since last pull.

In the query response, we receive a new delta URL to use for our next request, which captures our current query and makes it so the next response is incremental off the previous query. We store these delta URLs in the local representation of a user's subscription, to use periodically throughout a given day.

These delta URLs have the entire query encoded in them, including the date range used in the query. In order to always use a practical date range, we should update the delta query once a day, moving the range start and end forward one day. This is what `InitPolling` does, whereas `Poll` runs several times a day.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-22457

#### Todos

- Create job to run `InitPolling` once a day, and `Poll` every 5 minutes (or something similar)
- Make job scalable for several users, with batch requests
- Possibly delay the queuing of the simulated notification, to avoid race conditions of a real notification
- Review exposure of `NotificationProcessor` on `mscalendar` struct. It is not exposed on the interface, so other packages besides `plugin` correctly cannot access the `NotificationProcessor`

#### Additional Info

If a real notification comes in for the same event that is being processed by a delta link, there will be "no changes" to process, so the one that is processed last will be dropped, correctly. We should probably have a delay when queuing a notification from a delta link, so we avoid race conditions with a real notification.

If an event is created/updated/deleted outside of the date range used in the query, it will not be found in the delta query. When we eventually receive it using `InitPolling`, we will store it in the kvstore, but not make a DM for the user. If the event changes after it is in the kvstore, we will create a DM.