### PR TITLE
Fix findmeetings typo

### DIFF
--- a/server/command/command.go
+++ b/server/command/command.go
@@ -45,7 +45,7 @@ func Register(registerFunc RegisterFunc) {
 		DisplayName:      "Microsoft Calendar",
 		Description:      "Interact with your outlook calendar.",
 		AutoComplete:     true,
-		AutoCompleteDesc: "info, connect, disconnect, connect_bot, disconnect_bot, subscribe, showcals, viewcal, createcal, deletecal, createevent, findmeetings, availability",
+		AutoCompleteDesc: "help, info, connect, disconnect, connect_bot, disconnect_bot, subscribe, showcals, viewcal, createcal, deletecal, createevent, findmeetings, availability",
 		AutoCompleteHint: "(subcommand)",
 	})
 }

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -45,7 +45,7 @@ func Register(registerFunc RegisterFunc) {
 		DisplayName:      "Microsoft Calendar",
 		Description:      "Interact with your outlook calendar.",
 		AutoComplete:     true,
-		AutoCompleteDesc: "info, connect, viewcal, createcal, testcreateevent, deletecal, subscribe, findmeetings, showcals, availability",
+		AutoCompleteDesc: "info, connect, disconnect, connect_bot, disconnect_bot, subscribe, showcals, viewcal, createcal, deletecal, createevent, findmeetings, availability",
 		AutoCompleteHint: "(subcommand)",
 	})
 }

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -45,7 +45,7 @@ func Register(registerFunc RegisterFunc) {
 		DisplayName:      "Microsoft Calendar",
 		Description:      "Interact with your outlook calendar.",
 		AutoComplete:     true,
-		AutoCompleteDesc: "info, connect, viewcal, createcal, testcreateevent, deletecal, subscribe, findMeetings, showcals, availability",
+		AutoCompleteDesc: "info, connect, viewcal, createcal, testcreateevent, deletecal, subscribe, findmeetings, showcals, availability",
 		AutoCompleteHint: "(subcommand)",
 	})
 }


### PR DESCRIPTION
#### Summary
There is a typo in the autocomplete description for the `/mscalendar` command, and since the command is case-sensitive it will not work if typed as shown. It should be `findmeetings`. I didn't find any other instances of this typo in the repository.