### PR TITLE
Use KVSetWithOptions with Atomic: true

### DIFF
--- a/server/command/daily_summary.go
+++ b/server/command/daily_summary.go
@@ -40,7 +40,7 @@ func (c *Command) dailySummary(parameters ...string) (string, error) {
 
 		return dailySummaryResponse(dsum), nil
 	case "settings":
-		dsum, err := c.MSCalendar.GetDailySummaryUserSettingsForUser(c.user())
+		dsum, err := c.MSCalendar.GetDailySummarySettingsForUser(c.user())
 		if err != nil {
 			return err.Error() + "\nYou may need to configure your daily summary using the commands below.\n" + dailySummaryHelp, nil
 		}

--- a/server/command/daily_summary.go
+++ b/server/command/daily_summary.go
@@ -40,7 +40,7 @@ func (c *Command) dailySummary(parameters ...string) (string, error) {
 
 		return dailySummaryResponse(dsum), nil
 	case "settings":
-		dsum, err := c.MSCalendar.GetDailySummarySettingsForUser(c.user())
+		dsum, err := c.MSCalendar.GetDailySummaryUserSettingsForUser(c.user())
 		if err != nil {
 			return err.Error() + "\nYou may need to configure your daily summary using the commands below.\n" + dailySummaryHelp, nil
 		}
@@ -64,7 +64,7 @@ func (c *Command) dailySummary(parameters ...string) (string, error) {
 	}
 }
 
-func dailySummaryResponse(dsum *store.DailySummarySettings) string {
+func dailySummaryResponse(dsum *store.DailySummaryUserSettings) string {
 	if dsum.PostTime == "" {
 		return "Your daily summary time is not yet configured.\n" + dailySummarySetTimeErrorMessage
 	}

--- a/server/mscalendar/availability.go
+++ b/server/mscalendar/availability.go
@@ -23,7 +23,12 @@ type Availability interface {
 }
 
 func (m *mscalendar) SyncStatus(mattermostUserID string) (string, error) {
-	return m.syncStatusUsers([]string{mattermostUserID})
+	user, err := m.Store.LoadUserFromIndex(mattermostUserID)
+	if err != nil {
+		return "", err
+	}
+
+	return m.syncStatusUsers(store.UserIndex{user})
 }
 
 func (m *mscalendar) SyncStatusAll() (string, error) {
@@ -35,17 +40,10 @@ func (m *mscalendar) SyncStatusAll() (string, error) {
 		return "", err
 	}
 
-	allIDs := userIndex.GetMattermostUserIDs()
-	filteredIDs := []string{}
-	for _, id := range allIDs {
-		if id != m.Config.BotUserID {
-			filteredIDs = append(filteredIDs, id)
-		}
-	}
-	return m.syncStatusUsers(filteredIDs)
+	return m.syncStatusUsers(userIndex)
 }
 
-func (m *mscalendar) syncStatusUsers(mattermostUserIDs []string) (string, error) {
+func (m *mscalendar) syncStatusUsers(users store.UserIndex) (string, error) {
 	err := m.Filter(
 		withClient,
 		withUserExpanded(m.actingUser),
@@ -54,29 +52,12 @@ func (m *mscalendar) syncStatusUsers(mattermostUserIDs []string) (string, error)
 		return "", err
 	}
 
-	fullUserIndex, err := m.Store.LoadUserIndex()
-	if err != nil {
-		if err.Error() == "not found" {
-			return "No users found in user index", nil
-		}
-		return "", err
-	}
-
-	filteredUsers := store.UserIndex{}
-	indexByMattermostUserID := fullUserIndex.ByMattermostID()
-
-	for _, mattermostUserID := range mattermostUserIDs {
-		if u, ok := indexByMattermostUserID[mattermostUserID]; ok {
-			filteredUsers = append(filteredUsers, u)
-		}
-	}
-
-	if len(filteredUsers) == 0 {
+	if len(users) == 0 {
 		return "No connected users found", nil
 	}
 
 	scheduleIDs := []string{}
-	for _, u := range filteredUsers {
+	for _, u := range users {
 		scheduleIDs = append(scheduleIDs, u.Email)
 	}
 
@@ -88,10 +69,11 @@ func (m *mscalendar) syncStatusUsers(mattermostUserIDs []string) (string, error)
 		return "No schedule info found", nil
 	}
 
-	return m.setUserStatuses(filteredUsers, schedules, mattermostUserIDs)
+	return m.setUserStatuses(users, schedules)
 }
 
-func (m *mscalendar) setUserStatuses(filteredUsers store.UserIndex, schedules []*remote.ScheduleInformation, mattermostUserIDs []string) (string, error) {
+func (m *mscalendar) setUserStatuses(users store.UserIndex, schedules []*remote.ScheduleInformation) (string, error) {
+	mattermostUserIDs := users.GetMattermostUserIDs()
 	statuses, appErr := m.PluginAPI.GetMattermostUserStatusesByIds(mattermostUserIDs)
 	if appErr != nil {
 		return "", appErr
@@ -101,7 +83,7 @@ func (m *mscalendar) setUserStatuses(filteredUsers store.UserIndex, schedules []
 		statusMap[s.UserId] = s.Status
 	}
 
-	usersByEmail := filteredUsers.ByEmail()
+	usersByEmail := users.ByEmail()
 	var res string
 	for _, s := range schedules {
 		if s.Error != nil {
@@ -125,7 +107,7 @@ func (m *mscalendar) setUserStatuses(filteredUsers store.UserIndex, schedules []
 }
 
 func (m *mscalendar) GetAvailabilities(remoteUserID string, scheduleIDs []string) ([]*remote.ScheduleInformation, error) {
-	client, err := m.MakeSuperuserClient()
+	err := m.Filter(withClient)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +115,7 @@ func (m *mscalendar) GetAvailabilities(remoteUserID string, scheduleIDs []string
 	start := remote.NewDateTime(time.Now().UTC(), "UTC")
 	end := remote.NewDateTime(time.Now().UTC().Add(availabilityTimeWindowSize*time.Minute), "UTC")
 
-	return client.GetSchedule(remoteUserID, scheduleIDs, start, end, availabilityTimeWindowSize)
+	return m.client.GetSchedule(remoteUserID, scheduleIDs, start, end, availabilityTimeWindowSize)
 }
 
 func (m *mscalendar) setStatusFromAvailability(mattermostUserID, currentStatus string, av remote.AvailabilityView) string {

--- a/server/mscalendar/availability_test.go
+++ b/server/mscalendar/availability_test.go
@@ -90,11 +90,6 @@ func TestSyncStatusAll(t *testing.T) {
 					RemoteID:         "user_remote_id",
 					Email:            "user_email@example.com",
 				},
-				&store.UserShort{
-					MattermostUserID: "bot_mm_id",
-					RemoteID:         "bot_remote_id",
-					Email:            "bot_email@example.com",
-				},
 			}, nil).AnyTimes()
 
 			token := &oauth2.Token{

--- a/server/mscalendar/client.go
+++ b/server/mscalendar/client.go
@@ -23,15 +23,8 @@ func (m *mscalendar) MakeClient() (remote.Client, error) {
 	return m.Remote.MakeClient(context.Background(), m.actingUser.OAuth2Token), nil
 }
 
-func (m *mscalendar) MakeSuperuserClient() (remote.Client, error) {
-	err := m.Filter(
-		withClient,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	token, err := m.client.GetSuperuserToken()
+func (m *mscalendar) MakeSuperuserClient(client remote.Client) (remote.Client, error) {
+	token, err := client.GetSuperuserToken()
 	if err != nil {
 		return nil, err
 	}

--- a/server/mscalendar/daily_summary.go
+++ b/server/mscalendar/daily_summary.go
@@ -17,14 +17,14 @@ const dailySummaryTimeWindow = time.Minute * 2
 var timeNowFunc = time.Now
 
 type DailySummary interface {
-	GetDailySummaryUserSettingsForUser(user *User) (*store.DailySummaryUserSettings, error)
+	GetDailySummarySettingsForUser(user *User) (*store.DailySummaryUserSettings, error)
 	SetDailySummaryPostTime(user *User, timeStr string) (*store.DailySummaryUserSettings, error)
 	SetDailySummaryEnabled(user *User, enable bool) (*store.DailySummaryUserSettings, error)
 	ProcessAllDailySummary() error
 	GetDailySummary(user *User) (string, error)
 }
 
-func (m *mscalendar) GetDailySummaryUserSettingsForUser(user *User) (*store.DailySummaryUserSettings, error) {
+func (m *mscalendar) GetDailySummarySettingsForUser(user *User) (*store.DailySummaryUserSettings, error) {
 	dsumIndex, err := m.Store.LoadDailySummaryIndex()
 	if err != nil {
 		return nil, err

--- a/server/mscalendar/daily_summary_test.go
+++ b/server/mscalendar/daily_summary_test.go
@@ -101,7 +101,7 @@ func TestShouldPostDailySummary(t *testing.T) {
 			c.Set(moment)
 			timeNowFunc = c.Now
 
-			dsum := &store.DailySummarySettings{
+			dsum := &store.DailySummaryUserSettings{
 				Enable:   tc.enabled,
 				PostTime: tc.postTime,
 				Timezone: tc.timeZone,

--- a/server/mscalendar/filters.go
+++ b/server/mscalendar/filters.go
@@ -45,6 +45,14 @@ func withClient(m *mscalendar) error {
 	if err != nil {
 		return err
 	}
+
+	if m.actingUser.MattermostUserID == m.Config.BotUserID {
+		client, err = m.MakeSuperuserClient(client)
+		if err != nil {
+			return err
+		}
+	}
+
 	m.client = client
 	return nil
 }
@@ -53,7 +61,11 @@ func withSuperuserClient(m *mscalendar) error {
 	if m.client != nil {
 		return nil
 	}
-	client, err := m.MakeSuperuserClient()
+	client, err := m.MakeClient()
+	if err != nil {
+		return err
+	}
+	client, err = m.MakeSuperuserClient(client)
 	if err != nil {
 		return err
 	}

--- a/server/mscalendar/mock_mscalendar/mock_mscalendar.go
+++ b/server/mscalendar/mock_mscalendar/mock_mscalendar.go
@@ -239,19 +239,19 @@ func (mr *MockMSCalendarMockRecorder) GetDailySummary(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDailySummary", reflect.TypeOf((*MockMSCalendar)(nil).GetDailySummary), arg0)
 }
 
-// GetDailySummaryUserSettingsForUser mocks base method
-func (m *MockMSCalendar) GetDailySummaryUserSettingsForUser(arg0 *mscalendar.User) (*store.DailySummaryUserSettings, error) {
+// GetDailySummarySettingsForUser mocks base method
+func (m *MockMSCalendar) GetDailySummarySettingsForUser(arg0 *mscalendar.User) (*store.DailySummaryUserSettings, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDailySummaryUserSettingsForUser", arg0)
+	ret := m.ctrl.Call(m, "GetDailySummarySettingsForUser", arg0)
 	ret0, _ := ret[0].(*store.DailySummaryUserSettings)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetDailySummaryUserSettingsForUser indicates an expected call of GetDailySummaryUserSettingsForUser
-func (mr *MockMSCalendarMockRecorder) GetDailySummaryUserSettingsForUser(arg0 interface{}) *gomock.Call {
+// GetDailySummarySettingsForUser indicates an expected call of GetDailySummarySettingsForUser
+func (mr *MockMSCalendarMockRecorder) GetDailySummarySettingsForUser(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDailySummaryUserSettingsForUser", reflect.TypeOf((*MockMSCalendar)(nil).GetDailySummaryUserSettingsForUser), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDailySummarySettingsForUser", reflect.TypeOf((*MockMSCalendar)(nil).GetDailySummarySettingsForUser), arg0)
 }
 
 // GetRemoteUser mocks base method

--- a/server/mscalendar/mock_mscalendar/mock_mscalendar.go
+++ b/server/mscalendar/mock_mscalendar/mock_mscalendar.go
@@ -239,19 +239,19 @@ func (mr *MockMSCalendarMockRecorder) GetDailySummary(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDailySummary", reflect.TypeOf((*MockMSCalendar)(nil).GetDailySummary), arg0)
 }
 
-// GetDailySummarySettingsForUser mocks base method
-func (m *MockMSCalendar) GetDailySummarySettingsForUser(arg0 *mscalendar.User) (*store.DailySummarySettings, error) {
+// GetDailySummaryUserSettingsForUser mocks base method
+func (m *MockMSCalendar) GetDailySummaryUserSettingsForUser(arg0 *mscalendar.User) (*store.DailySummaryUserSettings, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDailySummarySettingsForUser", arg0)
-	ret0, _ := ret[0].(*store.DailySummarySettings)
+	ret := m.ctrl.Call(m, "GetDailySummaryUserSettingsForUser", arg0)
+	ret0, _ := ret[0].(*store.DailySummaryUserSettings)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetDailySummarySettingsForUser indicates an expected call of GetDailySummarySettingsForUser
-func (mr *MockMSCalendarMockRecorder) GetDailySummarySettingsForUser(arg0 interface{}) *gomock.Call {
+// GetDailySummaryUserSettingsForUser indicates an expected call of GetDailySummaryUserSettingsForUser
+func (mr *MockMSCalendarMockRecorder) GetDailySummaryUserSettingsForUser(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDailySummarySettingsForUser", reflect.TypeOf((*MockMSCalendar)(nil).GetDailySummarySettingsForUser), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDailySummaryUserSettingsForUser", reflect.TypeOf((*MockMSCalendar)(nil).GetDailySummaryUserSettingsForUser), arg0)
 }
 
 // GetRemoteUser mocks base method
@@ -388,10 +388,10 @@ func (mr *MockMSCalendarMockRecorder) RespondToEvent(arg0, arg1, arg2 interface{
 }
 
 // SetDailySummaryEnabled mocks base method
-func (m *MockMSCalendar) SetDailySummaryEnabled(arg0 *mscalendar.User, arg1 bool) (*store.DailySummarySettings, error) {
+func (m *MockMSCalendar) SetDailySummaryEnabled(arg0 *mscalendar.User, arg1 bool) (*store.DailySummaryUserSettings, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetDailySummaryEnabled", arg0, arg1)
-	ret0, _ := ret[0].(*store.DailySummarySettings)
+	ret0, _ := ret[0].(*store.DailySummaryUserSettings)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -403,10 +403,10 @@ func (mr *MockMSCalendarMockRecorder) SetDailySummaryEnabled(arg0, arg1 interfac
 }
 
 // SetDailySummaryPostTime mocks base method
-func (m *MockMSCalendar) SetDailySummaryPostTime(arg0 *mscalendar.User, arg1 string) (*store.DailySummarySettings, error) {
+func (m *MockMSCalendar) SetDailySummaryPostTime(arg0 *mscalendar.User, arg1 string) (*store.DailySummaryUserSettings, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetDailySummaryPostTime", arg0, arg1)
-	ret0, _ := ret[0].(*store.DailySummarySettings)
+	ret0, _ := ret[0].(*store.DailySummaryUserSettings)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -415,20 +415,6 @@ func (m *MockMSCalendar) SetDailySummaryPostTime(arg0 *mscalendar.User, arg1 str
 func (mr *MockMSCalendarMockRecorder) SetDailySummaryPostTime(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDailySummaryPostTime", reflect.TypeOf((*MockMSCalendar)(nil).SetDailySummaryPostTime), arg0, arg1)
-}
-
-// StoreUserSettings mocks base method
-func (m *MockMSCalendar) StoreUserSettings(arg0 *mscalendar.User, arg1 *store.Settings) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StoreUserSettings", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// StoreUserSettings indicates an expected call of StoreUserSettings
-func (mr *MockMSCalendarMockRecorder) StoreUserSettings(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreUserSettings", reflect.TypeOf((*MockMSCalendar)(nil).StoreUserSettings), arg0, arg1)
 }
 
 // SyncStatus mocks base method

--- a/server/mscalendar/oauth2.go
+++ b/server/mscalendar/oauth2.go
@@ -96,7 +96,7 @@ func (app *oauth2App) CompleteOAuth2(authedUserID, code, state string) error {
 		return err
 	}
 
-	uid, err := app.Store.LoadMattermostUserId(me.ID)
+	uid, err := app.Store.LoadMattermostUserID(me.ID)
 	if err == nil {
 		user, userErr := app.PluginAPI.GetMattermostUser(uid)
 		if userErr == nil {
@@ -123,9 +123,14 @@ func (app *oauth2App) CompleteOAuth2(authedUserID, code, state string) error {
 
 	if mattermostUserID == app.Config.BotUserID {
 		app.Poster.DM(authedUserID, BotWelcomeMessage, me.Mail)
-	} else {
-		app.Poster.DM(mattermostUserID, WelcomeMessage, me.Mail)
+		return nil
 	}
 
+	err = app.Store.StoreUserInIndex(u)
+	if err != nil {
+		return err
+	}
+
+	app.Poster.DM(mattermostUserID, WelcomeMessage, me.Mail)
 	return nil
 }

--- a/server/mscalendar/oauth2_test.go
+++ b/server/mscalendar/oauth2_test.go
@@ -65,8 +65,9 @@ func TestCompleteOAuth2Happy(t *testing.T) {
 
 	gomock.InOrder(
 		ss.EXPECT().VerifyOAuth2State(gomock.Eq(state)).Return(nil).Times(1),
-		ss.EXPECT().LoadMattermostUserId(fakeRemoteID).Return("", errors.New("Connected user not found")).Times(1),
+		ss.EXPECT().LoadMattermostUserID(fakeRemoteID).Return("", errors.New("Connected user not found")).Times(1),
 		ss.EXPECT().StoreUser(gomock.Any()).Return(nil).Times(1),
+		ss.EXPECT().StoreUserInIndex(gomock.Any()).Return(nil).Times(1),
 		poster.EXPECT().DM(
 			gomock.Eq(fakeID),
 			gomock.Eq(WelcomeMessage),
@@ -112,7 +113,7 @@ func TestCompleteOAuth2ForBotHappy(t *testing.T) {
 
 	gomock.InOrder(
 		ss.EXPECT().VerifyOAuth2State(gomock.Eq(state)).Return(nil).Times(1),
-		ss.EXPECT().LoadMattermostUserId(fakeRemoteID).Return("", errors.New("Connected user not found")).Times(1),
+		ss.EXPECT().LoadMattermostUserID(fakeRemoteID).Return("", errors.New("Connected user not found")).Times(1),
 		ss.EXPECT().StoreUser(gomock.Any()).Return(nil).Times(1),
 		poster.EXPECT().DM(
 			gomock.Eq(fakeID),
@@ -317,7 +318,7 @@ func TestCompleteOAuth2Errors(t *testing.T) {
 				papi.EXPECT().GetMattermostUser("fake@mattermost.com").Return(&model.User{Username: "sample-username"}, nil)
 
 				ss := d.Store.(*mock_store.MockStore)
-				ss.EXPECT().LoadMattermostUserId("user-remote-id").Return("fake@mattermost.com", nil)
+				ss.EXPECT().LoadMattermostUserID("user-remote-id").Return("fake@mattermost.com", nil)
 				ss.EXPECT().VerifyOAuth2State(gomock.Eq("user_fake@mattermost.com")).Return(nil).Times(1)
 
 				poster := d.Poster.(*mock_bot.MockPoster)
@@ -352,7 +353,7 @@ func TestCompleteOAuth2Errors(t *testing.T) {
 			setup: func(d *Dependencies) {
 				ss := d.Store.(*mock_store.MockStore)
 				ss.EXPECT().StoreUser(gomock.Any()).Return(errors.New("forced kvstore error")).Times(1)
-				ss.EXPECT().LoadMattermostUserId("user-remote-id").Return("", errors.New("Connected user not found")).Times(1)
+				ss.EXPECT().LoadMattermostUserID("user-remote-id").Return("", errors.New("Connected user not found")).Times(1)
 				ss.EXPECT().VerifyOAuth2State(gomock.Eq("user_fake@mattermost.com")).Return(nil).Times(1)
 			},
 			expectError: "forced kvstore error",

--- a/server/store/daily_summary_store.go
+++ b/server/store/daily_summary_store.go
@@ -4,16 +4,20 @@
 package store
 
 import (
+	"encoding/json"
+
 	"github.com/mattermost/mattermost-plugin-mscalendar/server/utils/kvstore"
 )
 
 type DailySummaryStore interface {
 	LoadDailySummaryIndex() (DailySummaryIndex, error)
-	SaveDailySummaryIndex(dsumIndex DailySummaryIndex) error
-	DeleteDailySummarySettings(mattermostUserID string) error
+	LoadDailySummaryUserSettings(mattermostUserID string) (*DailySummaryUserSettings, error)
+	StoreDailySummaryUserSettings(dsum *DailySummaryUserSettings) error
+	DeleteDailySummaryUserSettings(mattermostUserID string) error
+	ModifyDailySummaryIndex(modify func(dsumIndex DailySummaryIndex) (DailySummaryIndex, error)) error
 }
 
-type DailySummarySettings struct {
+type DailySummaryUserSettings struct {
 	MattermostUserID string `json:"mm_id"`
 	Enable           bool   `json:"enable"`
 	PostTime         string `json:"post_time"` // Kitchen format, i.e. 8:30AM
@@ -21,7 +25,7 @@ type DailySummarySettings struct {
 	LastPostTime     string `json:"last_post_time"`
 }
 
-type DailySummaryIndex []*DailySummarySettings
+type DailySummaryIndex []*DailySummaryUserSettings
 
 func (s *pluginStore) LoadDailySummaryIndex() (DailySummaryIndex, error) {
 	dsumIndex := DailySummaryIndex{}
@@ -32,25 +36,70 @@ func (s *pluginStore) LoadDailySummaryIndex() (DailySummaryIndex, error) {
 	return dsumIndex, nil
 }
 
-func (s *pluginStore) SaveDailySummaryIndex(dsumIndex DailySummaryIndex) error {
-	err := kvstore.StoreJSON(s.dailySummaryKV, "", &dsumIndex)
+func (s *pluginStore) LoadDailySummaryUserSettings(mattermostUserID string) (*DailySummaryUserSettings, error) {
+	index, err := s.LoadDailySummaryIndex()
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
-}
-
-func (s *pluginStore) DeleteDailySummarySettings(mattermostUserID string) error {
-	users, err := s.LoadDailySummaryIndex()
-	if err != nil {
-		return err
+	if index == nil {
+		return nil, nil
 	}
 
-	result := DailySummaryIndex{}
-	for _, u := range users {
-		if u.MattermostUserID != mattermostUserID {
-			result = append(result, u)
+	for _, dsum := range index {
+		if dsum.MattermostUserID == mattermostUserID {
+			return dsum, nil
 		}
 	}
-	return s.SaveDailySummaryIndex(result)
+	return nil, nil
+}
+
+func (s *pluginStore) StoreDailySummaryUserSettings(toStore *DailySummaryUserSettings) error {
+	return s.ModifyDailySummaryIndex(func(dsumIndex DailySummaryIndex) (DailySummaryIndex, error) {
+		for i, dsum := range dsumIndex {
+			if dsum.MattermostUserID == toStore.MattermostUserID {
+				result := append(dsumIndex[:i], toStore)
+				return append(result, dsumIndex[i+1:]...), nil
+			}
+		}
+
+		return append(dsumIndex, toStore), nil
+	})
+}
+
+func (s *pluginStore) DeleteDailySummaryUserSettings(mattermostUserID string) error {
+	return s.ModifyDailySummaryIndex(func(dsumIndex DailySummaryIndex) (DailySummaryIndex, error) {
+		for i, u := range dsumIndex {
+			if u.MattermostUserID == mattermostUserID {
+				return append(dsumIndex[:i], dsumIndex[i+1:]...), nil
+			}
+		}
+		return dsumIndex, nil
+	})
+}
+
+func (s *pluginStore) ModifyDailySummaryIndex(modify func(dsumIndex DailySummaryIndex) (DailySummaryIndex, error)) error {
+	return kvstore.AtomicModify(s.dailySummaryKV, "", func(initialBytes []byte, storeErr error) ([]byte, error) {
+		if storeErr != nil && storeErr != ErrNotFound {
+			return nil, storeErr
+		}
+
+		storedSettings := DailySummaryIndex{}
+		if len(initialBytes) > 0 {
+			err := json.Unmarshal(initialBytes, &storedSettings)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		updated, err := modify(storedSettings)
+		if err != nil {
+			return nil, err
+		}
+		b, err := json.Marshal(updated)
+		if err != nil {
+			return nil, err
+		}
+
+		return b, nil
+	})
 }

--- a/server/store/mock_store/mock_store.go
+++ b/server/store/mock_store/mock_store.go
@@ -33,18 +33,18 @@ func (m *MockStore) EXPECT() *MockStoreMockRecorder {
 	return m.recorder
 }
 
-// DeleteDailySummarySettings mocks base method
-func (m *MockStore) DeleteDailySummarySettings(arg0 string) error {
+// DeleteDailySummaryUserSettings mocks base method
+func (m *MockStore) DeleteDailySummaryUserSettings(arg0 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteDailySummarySettings", arg0)
+	ret := m.ctrl.Call(m, "DeleteDailySummaryUserSettings", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeleteDailySummarySettings indicates an expected call of DeleteDailySummarySettings
-func (mr *MockStoreMockRecorder) DeleteDailySummarySettings(arg0 interface{}) *gomock.Call {
+// DeleteDailySummaryUserSettings indicates an expected call of DeleteDailySummaryUserSettings
+func (mr *MockStoreMockRecorder) DeleteDailySummaryUserSettings(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDailySummarySettings", reflect.TypeOf((*MockStore)(nil).DeleteDailySummarySettings), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDailySummaryUserSettings", reflect.TypeOf((*MockStore)(nil).DeleteDailySummaryUserSettings), arg0)
 }
 
 // DeleteUser mocks base method
@@ -73,6 +73,20 @@ func (m *MockStore) DeleteUserEvent(arg0, arg1 string) error {
 func (mr *MockStoreMockRecorder) DeleteUserEvent(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUserEvent", reflect.TypeOf((*MockStore)(nil).DeleteUserEvent), arg0, arg1)
+}
+
+// DeleteUserFromIndex mocks base method
+func (m *MockStore) DeleteUserFromIndex(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteUserFromIndex", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteUserFromIndex indicates an expected call of DeleteUserFromIndex
+func (mr *MockStoreMockRecorder) DeleteUserFromIndex(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUserFromIndex", reflect.TypeOf((*MockStore)(nil).DeleteUserFromIndex), arg0)
 }
 
 // DeleteUserSubscription mocks base method
@@ -104,19 +118,34 @@ func (mr *MockStoreMockRecorder) LoadDailySummaryIndex() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadDailySummaryIndex", reflect.TypeOf((*MockStore)(nil).LoadDailySummaryIndex))
 }
 
-// LoadMattermostUserId mocks base method
-func (m *MockStore) LoadMattermostUserId(arg0 string) (string, error) {
+// LoadDailySummaryUserSettings mocks base method
+func (m *MockStore) LoadDailySummaryUserSettings(arg0 string) (*store.DailySummaryUserSettings, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LoadMattermostUserId", arg0)
+	ret := m.ctrl.Call(m, "LoadDailySummaryUserSettings", arg0)
+	ret0, _ := ret[0].(*store.DailySummaryUserSettings)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LoadDailySummaryUserSettings indicates an expected call of LoadDailySummaryUserSettings
+func (mr *MockStoreMockRecorder) LoadDailySummaryUserSettings(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadDailySummaryUserSettings", reflect.TypeOf((*MockStore)(nil).LoadDailySummaryUserSettings), arg0)
+}
+
+// LoadMattermostUserID mocks base method
+func (m *MockStore) LoadMattermostUserID(arg0 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LoadMattermostUserID", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// LoadMattermostUserId indicates an expected call of LoadMattermostUserId
-func (mr *MockStoreMockRecorder) LoadMattermostUserId(arg0 interface{}) *gomock.Call {
+// LoadMattermostUserID indicates an expected call of LoadMattermostUserID
+func (mr *MockStoreMockRecorder) LoadMattermostUserID(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadMattermostUserId", reflect.TypeOf((*MockStore)(nil).LoadMattermostUserId), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadMattermostUserID", reflect.TypeOf((*MockStore)(nil).LoadMattermostUserID), arg0)
 }
 
 // LoadSubscription mocks base method
@@ -164,6 +193,21 @@ func (mr *MockStoreMockRecorder) LoadUserEvent(arg0, arg1 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadUserEvent", reflect.TypeOf((*MockStore)(nil).LoadUserEvent), arg0, arg1)
 }
 
+// LoadUserFromIndex mocks base method
+func (m *MockStore) LoadUserFromIndex(arg0 string) (*store.UserShort, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LoadUserFromIndex", arg0)
+	ret0, _ := ret[0].(*store.UserShort)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LoadUserFromIndex indicates an expected call of LoadUserFromIndex
+func (mr *MockStoreMockRecorder) LoadUserFromIndex(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadUserFromIndex", reflect.TypeOf((*MockStore)(nil).LoadUserFromIndex), arg0)
+}
+
 // LoadUserIndex mocks base method
 func (m *MockStore) LoadUserIndex() (store.UserIndex, error) {
 	m.ctrl.T.Helper()
@@ -179,18 +223,46 @@ func (mr *MockStoreMockRecorder) LoadUserIndex() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadUserIndex", reflect.TypeOf((*MockStore)(nil).LoadUserIndex))
 }
 
-// SaveDailySummaryIndex mocks base method
-func (m *MockStore) SaveDailySummaryIndex(arg0 store.DailySummaryIndex) error {
+// ModifyDailySummaryIndex mocks base method
+func (m *MockStore) ModifyDailySummaryIndex(arg0 func(store.DailySummaryIndex) (store.DailySummaryIndex, error)) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SaveDailySummaryIndex", arg0)
+	ret := m.ctrl.Call(m, "ModifyDailySummaryIndex", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// SaveDailySummaryIndex indicates an expected call of SaveDailySummaryIndex
-func (mr *MockStoreMockRecorder) SaveDailySummaryIndex(arg0 interface{}) *gomock.Call {
+// ModifyDailySummaryIndex indicates an expected call of ModifyDailySummaryIndex
+func (mr *MockStoreMockRecorder) ModifyDailySummaryIndex(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveDailySummaryIndex", reflect.TypeOf((*MockStore)(nil).SaveDailySummaryIndex), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyDailySummaryIndex", reflect.TypeOf((*MockStore)(nil).ModifyDailySummaryIndex), arg0)
+}
+
+// ModifyUserIndex mocks base method
+func (m *MockStore) ModifyUserIndex(arg0 func(store.UserIndex) (store.UserIndex, error)) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ModifyUserIndex", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ModifyUserIndex indicates an expected call of ModifyUserIndex
+func (mr *MockStoreMockRecorder) ModifyUserIndex(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyUserIndex", reflect.TypeOf((*MockStore)(nil).ModifyUserIndex), arg0)
+}
+
+// StoreDailySummaryUserSettings mocks base method
+func (m *MockStore) StoreDailySummaryUserSettings(arg0 *store.DailySummaryUserSettings) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StoreDailySummaryUserSettings", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StoreDailySummaryUserSettings indicates an expected call of StoreDailySummaryUserSettings
+func (mr *MockStoreMockRecorder) StoreDailySummaryUserSettings(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreDailySummaryUserSettings", reflect.TypeOf((*MockStore)(nil).StoreDailySummaryUserSettings), arg0)
 }
 
 // StoreOAuth2State mocks base method
@@ -233,6 +305,20 @@ func (m *MockStore) StoreUserEvent(arg0 string, arg1 *store.Event) error {
 func (mr *MockStoreMockRecorder) StoreUserEvent(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreUserEvent", reflect.TypeOf((*MockStore)(nil).StoreUserEvent), arg0, arg1)
+}
+
+// StoreUserInIndex mocks base method
+func (m *MockStore) StoreUserInIndex(arg0 *store.User) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StoreUserInIndex", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StoreUserInIndex indicates an expected call of StoreUserInIndex
+func (mr *MockStoreMockRecorder) StoreUserInIndex(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreUserInIndex", reflect.TypeOf((*MockStore)(nil).StoreUserInIndex), arg0)
 }
 
 // StoreUserSubscription mocks base method

--- a/server/utils/kvstore/hashed_key.go
+++ b/server/utils/kvstore/hashed_key.go
@@ -6,6 +6,8 @@ package kvstore
 import (
 	"crypto/md5"
 	"fmt"
+
+	"github.com/mattermost/mattermost-server/v5/model"
 )
 
 type hashedKeyStore struct {
@@ -32,6 +34,10 @@ func (s hashedKeyStore) Store(key string, data []byte) error {
 
 func (s hashedKeyStore) StoreTTL(key string, data []byte, ttlSeconds int64) error {
 	return s.store.StoreTTL(hashKey(s.prefix, key), data, ttlSeconds)
+}
+
+func (s hashedKeyStore) StoreWithOptions(key string, value []byte, opts model.PluginKVSetOptions) (bool, error) {
+	return s.store.StoreWithOptions(hashKey(s.prefix, key), value, opts)
 }
 
 func (s hashedKeyStore) Delete(key string) error {

--- a/server/utils/kvstore/kvstore.go
+++ b/server/utils/kvstore/kvstore.go
@@ -4,18 +4,28 @@
 package kvstore
 
 import (
+	"bytes"
 	"encoding/json"
-	"errors"
+	"time"
+
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/pkg/errors"
 )
 
 type KVStore interface {
 	Load(key string) ([]byte, error)
 	Store(key string, data []byte) error
 	StoreTTL(key string, data []byte, ttlSeconds int64) error
+	StoreWithOptions(key string, value []byte, opts model.PluginKVSetOptions) (bool, error)
 	Delete(key string) error
 }
 
 var ErrNotFound = errors.New("not found")
+
+const (
+	atomicRetryLimit = 5
+	atomicRetryWait  = 30 * time.Millisecond
+)
 
 func Ensure(s KVStore, key string, newValue []byte) ([]byte, error) {
 	value, err := s.Load(key)
@@ -55,4 +65,47 @@ func StoreJSON(s KVStore, key string, v interface{}) (returnErr error) {
 		return err
 	}
 	return s.Store(key, data)
+}
+
+func AtomicModifyWithOptions(s KVStore, key string, modify func(initialValue []byte, storeErr error) ([]byte, *model.PluginKVSetOptions, error)) error {
+	currentAttempt := 0
+	for {
+		initialBytes, appErr := s.Load(key)
+		newValue, opts, err := modify(initialBytes, appErr)
+		if err != nil {
+			return errors.Wrap(err, "modification error")
+		}
+
+		// No modifications have been done. No reason to hit the plugin API.
+		if bytes.Equal(initialBytes, newValue) {
+			return nil
+		}
+
+		if opts == nil {
+			opts = &model.PluginKVSetOptions{}
+		}
+		opts.Atomic = true
+		opts.OldValue = initialBytes
+		success, setError := s.StoreWithOptions(key, newValue, *opts)
+		if setError != nil {
+			return errors.Wrap(setError, "problem writing value")
+		}
+		if success {
+			return nil
+		}
+
+		currentAttempt++
+		if currentAttempt >= atomicRetryLimit {
+			return errors.New("reached write attempt limit")
+		}
+
+		time.Sleep(atomicRetryWait)
+	}
+}
+
+func AtomicModify(s KVStore, key string, modify func(initialValue []byte, storeErr error) ([]byte, error)) error {
+	return AtomicModifyWithOptions(s, key, func(initialValue []byte, storeErr error) ([]byte, *model.PluginKVSetOptions, error) {
+		b, err := modify(initialValue, storeErr)
+		return b, nil, err
+	})
 }

--- a/server/utils/kvstore/plugin_store.go
+++ b/server/utils/kvstore/plugin_store.go
@@ -62,6 +62,18 @@ func (s pluginStore) StoreTTL(key string, data []byte, ttlSeconds int64) error {
 	return nil
 }
 
+func (s pluginStore) StoreWithOptions(key string, value []byte, opts model.PluginKVSetOptions) (bool, error) {
+	if opts.ExpireInSeconds == 0 && s.ttlSeconds > 0 {
+		opts.ExpireInSeconds = s.ttlSeconds
+	}
+
+	success, appErr := s.api.KVSetWithOptions(key, value, opts)
+	if appErr != nil {
+		return false, errors.WithMessagef(appErr, "failed plugin KVSet (ttl: %vs) %q", opts.ExpireInSeconds, key)
+	}
+	return success, nil
+}
+
 func (s pluginStore) Delete(key string) error {
 	appErr := s.api.KVDelete(key)
 	if appErr != nil {


### PR DESCRIPTION
#### Summary

This PR uses the `Atomic` KVOption to ensure that the kv value used for the operation is up to date upon save.

The atomic saves are used in all contexts where the current value affects the operation being done. For other cases, we are creating new entries in the store, in which case the names of the methods are StoreNewUser etc.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-mscalendar/issues/47