### PR TITLE
Use correct prefix for OAuth2 store keys

### DIFF
--- a/server/store/oauth2_store.go
+++ b/server/store/oauth2_store.go
@@ -13,7 +13,7 @@ type OAuth2StateStore interface {
 }
 
 func (s *pluginStore) VerifyOAuth2State(state string) error {
-	data, err := s.subscriptionKV.Load(state)
+	data, err := s.oauth2KV.Load(state)
 	if err != nil {
 		return err
 	}
@@ -24,5 +24,5 @@ func (s *pluginStore) VerifyOAuth2State(state string) error {
 }
 
 func (s *pluginStore) StoreOAuth2State(state string) error {
-	return s.subscriptionKV.Store(state, []byte(state))
+	return s.oauth2KV.Store(state, []byte(state))
 }


### PR DESCRIPTION
#### Summary

The `oauth2_store` was saving its values with the key prefix `sub_` when it should be using `oauth2_`

#### Ticket Link

Fixes #77
