### PR TITLE
[GH104] Check when the error when cleaning a setting post is not found

### DIFF
--- a/server/mscalendar/settings.go
+++ b/server/mscalendar/settings.go
@@ -16,7 +16,10 @@ func (c *mscalendar) PrintSettings(userID string) {
 }
 
 func (c *mscalendar) ClearSettingsPosts(userID string) {
-	c.SettingsPanel.Clear(userID)
+	err := c.SettingsPanel.Clear(userID)
+	if err != nil {
+		c.Logger.Warnf("error clearing settings posts, " + err.Error())
+	}
 }
 
 func NewSettingsPanel(bot bot.Bot, panelStore settingspanel.PanelStore, settingStore settingspanel.SettingStore, settingsHandler, pluginURL string, getTimezone func(userID string) (string, error)) settingspanel.Panel {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Remove the server error that occurred when a new user opened the settings panel, and there was no previous panel to delete. This was caused by not handling the "not found" error of the store.

#### Ticket Link
#104 

