### PR TITLE
Ensure subject is shown as "(No subject)" where appropriate

### DIFF
--- a/server/mscalendar/notification.go
+++ b/server/mscalendar/notification.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mattermost/mattermost-server/v5/model"
 
 	"github.com/mattermost/mattermost-plugin-mscalendar/server/config"
+	"github.com/mattermost/mattermost-plugin-mscalendar/server/mscalendar/views"
 	"github.com/mattermost/mattermost-plugin-mscalendar/server/remote"
 	"github.com/mattermost/mattermost-plugin-mscalendar/server/store"
 	"github.com/mattermost/mattermost-plugin-mscalendar/server/utils/bot"
@@ -221,7 +222,7 @@ func (processor *notificationProcessor) newSlackAttachment(n *remote.Notificatio
 		AuthorName: n.Event.Organizer.EmailAddress.Name,
 		AuthorLink: "mailto:" + n.Event.Organizer.EmailAddress.Address,
 		TitleLink:  n.Event.Weblink,
-		Title:      n.Event.Subject,
+		Title:      views.EnsureSubject(n.Event.Subject),
 		Text:       n.Event.BodyPreview,
 	}
 }
@@ -449,7 +450,7 @@ func eventToFields(e *remote.Event) fields.Fields {
 	}
 
 	ff := fields.Fields{
-		FieldSubject:     fields.NewStringValue(valueOrNotDefined(e.Subject)),
+		FieldSubject:     fields.NewStringValue(views.EnsureSubject(e.Subject)),
 		FieldBodyPreview: fields.NewStringValue(valueOrNotDefined(e.BodyPreview)),
 		FieldImportance:  fields.NewStringValue(valueOrNotDefined(e.Importance)),
 		FieldWhen:        fields.NewStringValue(valueOrNotDefined(formattedDate)),

--- a/server/mscalendar/views/calendar.go
+++ b/server/mscalendar/views/calendar.go
@@ -56,7 +56,9 @@ func renderEvent(event *remote.Event, asRow bool) (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf(format, start, end, event.Subject, link), nil
+	subject := EnsureSubject(event.Subject)
+
+	return fmt.Sprintf(format, start, end, subject, link), nil
 }
 
 func groupEventsByDate(events []*remote.Event) [][]*remote.Event {
@@ -94,4 +96,12 @@ func RenderUpcomingEvent(event *remote.Event, timezone string) (string, error) {
 	}
 
 	return message + eventString, nil
+}
+
+func EnsureSubject(s string) string {
+	if s == "" {
+		return "(No subject)"
+	}
+
+	return s
 }


### PR DESCRIPTION
#### Summary

The two places I didn't convert are:
- The sentences where we say "Without a subject"
- When we create the `PostAction.Integration.Context`, and use the subject in the URL

#### Ticket Link

Fixes #109 