### PR TITLE
Use timezone when displaying event details

### DIFF
--- a/server/mscalendar/notification_test.go
+++ b/server/mscalendar/notification_test.go
@@ -58,6 +58,7 @@ func newTestSubscription() *store.Subscription {
 		Remote: &remote.Subscription{
 			ID:          "remote_subscription_id",
 			ClientState: "stored_client_state",
+			CreatorID:   "remote_user_id",
 		},
 		MattermostCreatorID: "creator_mm_id",
 	}
@@ -68,7 +69,7 @@ func newTestUser() *store.User {
 		Settings: store.Settings{
 			EventSubscriptionID: "remote_subscription_id",
 		},
-		Remote: &remote.User{},
+		Remote: &remote.User{ID: "remote_user_id"},
 		OAuth2Token: &oauth2.Token{
 			AccessToken: "creator_oauth_token",
 		},
@@ -152,6 +153,7 @@ func TestProcessNotification(t *testing.T) {
 				mockRemote.EXPECT().MakeClient(context.Background(), &oauth2.Token{
 					AccessToken: "creator_oauth_token",
 				}).Return(mockClient).Times(1)
+				mockClient.EXPECT().GetMailboxSettings(user.Remote.ID).Return(&remote.MailboxSettings{TimeZone: "Eastern Standard Time"}, nil)
 
 				if tc.notification.RecommendRenew {
 					mockClient.EXPECT().RenewSubscription("remote_subscription_id").Return(&remote.Subscription{}, nil).Times(1)

--- a/server/mscalendar/views/calendar.go
+++ b/server/mscalendar/views/calendar.go
@@ -26,7 +26,7 @@ func RenderCalendarView(events []*remote.Event, timeZone string) (string, error)
 		resp += "\n" + group[0].Start.Time().Format("Monday January 02") + "\n\n"
 		resp += renderTableHeader()
 		for _, e := range group {
-			eventString, err := renderEvent(e, true)
+			eventString, err := renderEvent(e, true, timeZone)
 			if err != nil {
 				return "", err
 			}
@@ -42,9 +42,9 @@ func renderTableHeader() string {
 | :--: | :-- |`
 }
 
-func renderEvent(event *remote.Event, asRow bool) (string, error) {
-	start := event.Start.Time().Format(time.Kitchen)
-	end := event.End.Time().Format(time.Kitchen)
+func renderEvent(event *remote.Event, asRow bool, timeZone string) (string, error) {
+	start := event.Start.In(timeZone).Time().Format(time.Kitchen)
+	end := event.End.In(timeZone).Time().Format(time.Kitchen)
 
 	format := "(%s - %s) [%s](%s)"
 	if asRow {
@@ -86,9 +86,9 @@ func groupEventsByDate(events []*remote.Event) [][]*remote.Event {
 	return result
 }
 
-func RenderUpcomingEvent(event *remote.Event, timezone string) (string, error) {
+func RenderUpcomingEvent(event *remote.Event, timeZone string) (string, error) {
 	message := "You have an upcoming event:\n"
-	eventString, err := renderEvent(event, false)
+	eventString, err := renderEvent(event, false, timeZone)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
#### Summary

The event invitation details logic was not using the user's timezone when displaying the event times

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-mscalendar/issues/128