### PR TITLE
Fix missing remote user id in daily summary settings

### DIFF
--- a/server/mscalendar/daily_summary.go
+++ b/server/mscalendar/daily_summary.go
@@ -54,7 +54,7 @@ func (m *mscalendar) SetDailySummaryPostTime(user *User, timeStr string) (*store
 		return nil, fmt.Errorf("Time must be a multiple of %d minutes.", DailySummaryJobInterval/time.Minute)
 	}
 
-	err := m.Filter(
+	err = m.Filter(
 		withRemoteUser(user),
 	)
 	if err != nil {

--- a/server/mscalendar/daily_summary.go
+++ b/server/mscalendar/daily_summary.go
@@ -64,11 +64,12 @@ func (m *mscalendar) SetDailySummaryPostTime(user *User, timeStr string) (*store
 		return nil, err
 	}
 	if dsum == nil {
-		dsum = &store.DailySummaryUserSettings{MattermostUserID: user.MattermostUserID, RemoteID: user.Remote.ID}
+		dsum = &store.DailySummaryUserSettings{MattermostUserID: user.MattermostUserID}
 	}
 
 	dsum.PostTime = timeStr
 	dsum.Timezone = timezone
+	dsum.RemoteID = user.Remote.ID
 
 	err = m.Store.StoreDailySummaryUserSettings(dsum)
 	if err != nil {
@@ -91,9 +92,10 @@ func (m *mscalendar) SetDailySummaryEnabled(user *User, enable bool) (*store.Dai
 		return nil, err
 	}
 	if dsum == nil {
-		dsum = &store.DailySummaryUserSettings{MattermostUserID: user.MattermostUserID, RemoteID: user.Remote.ID}
+		dsum = &store.DailySummaryUserSettings{MattermostUserID: user.MattermostUserID}
 	}
 	dsum.Enable = enable
+	dsum.RemoteID = user.Remote.ID
 
 	err = m.Store.StoreDailySummaryUserSettings(dsum)
 	if err != nil {

--- a/server/mscalendar/daily_summary.go
+++ b/server/mscalendar/daily_summary.go
@@ -54,6 +54,13 @@ func (m *mscalendar) SetDailySummaryPostTime(user *User, timeStr string) (*store
 		return nil, fmt.Errorf("Time must be a multiple of %d minutes.", DailySummaryJobInterval/time.Minute)
 	}
 
+	err := m.Filter(
+		withRemoteUser(user),
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	timezone, err := m.GetTimezone(user)
 	if err != nil {
 		return nil, err
@@ -80,8 +87,7 @@ func (m *mscalendar) SetDailySummaryPostTime(user *User, timeStr string) (*store
 
 func (m *mscalendar) SetDailySummaryEnabled(user *User, enable bool) (*store.DailySummaryUserSettings, error) {
 	err := m.Filter(
-		withClient,
-		withUserExpanded(user),
+		withRemoteUser(user),
 	)
 	if err != nil {
 		return nil, err

--- a/server/mscalendar/daily_summary.go
+++ b/server/mscalendar/daily_summary.go
@@ -64,7 +64,7 @@ func (m *mscalendar) SetDailySummaryPostTime(user *User, timeStr string) (*store
 		return nil, err
 	}
 	if dsum == nil {
-		dsum = &store.DailySummaryUserSettings{MattermostUserID: user.MattermostUserID}
+		dsum = &store.DailySummaryUserSettings{MattermostUserID: user.MattermostUserID, RemoteID: user.Remote.ID}
 	}
 
 	dsum.PostTime = timeStr
@@ -91,7 +91,7 @@ func (m *mscalendar) SetDailySummaryEnabled(user *User, enable bool) (*store.Dai
 		return nil, err
 	}
 	if dsum == nil {
-		dsum = &store.DailySummaryUserSettings{MattermostUserID: user.MattermostUserID}
+		dsum = &store.DailySummaryUserSettings{MattermostUserID: user.MattermostUserID, RemoteID: user.Remote.ID}
 	}
 	dsum.Enable = enable
 

--- a/server/store/setting_store.go
+++ b/server/store/setting_store.go
@@ -96,8 +96,14 @@ func (s *pluginStore) updateDailySummarySettingForUser(userID string, value inte
 			timeStr = "8:00AM"
 		}
 
+		user, err := s.LoadUser(userID)
+		if err != nil {
+			return err
+		}
+
 		dsum = &DailySummaryUserSettings{
 			MattermostUserID: userID,
+			RemoteID:         user.Remote.ID,
 			PostTime:         timeStr,
 			Timezone:         timezone,
 			Enable:           splittedValue[0] == "true",

--- a/server/store/setting_store.go
+++ b/server/store/setting_store.go
@@ -96,9 +96,9 @@ func (s *pluginStore) updateDailySummarySettingForUser(userID string, value inte
 			timeStr = "8:00AM"
 		}
 
-		user, err := s.LoadUser(userID)
-		if err != nil {
-			return err
+		user, loadUserErr := s.LoadUser(userID)
+		if loadUserErr != nil {
+			return loadUserErr
 		}
 
 		dsum = &DailySummaryUserSettings{


### PR DESCRIPTION
#### Summary

The remote user ID was not being set properly when creating the user's daily summary settings.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-mscalendar/issues/130