### PR TITLE
Explain jobs and enable jobs by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,16 @@ Copy the `Client ID` and `Tenant ID` from the Azure portal
 - `tenantID` - copy from Azure App
 - `clientID` - copy from Azure App
 - `Client Secret` - copy from Azure App (Generated in `Certificates & secrets`, earlier in these instructions)
+
+**Scheduled Jobs**
+
+There are two scheduled jobs than can be disabled from the plugin settings in the system console.
+
+The Status Sync job runs every 5 minutes and is responsible for:
+
+- Applying status changes to Mattermost users when they are current availability on their calendar
+- Delivering upcoming event reminders to users
+
+The Daily Summary job runs every 15 minutes and is responsible for:
+
+- Delivering each user's calendar summary for the day, based on their settings of when they want to receive the summary

--- a/plugin.json
+++ b/plugin.json
@@ -84,14 +84,14 @@
                 "display_name": "Enable User Status Sync Job",
                 "type": "bool",
                 "help_text": "When enabled, a Mattermost user's status will automatically update based on their Microsoft Calendar availability. This runs every 5 minutes.",
-                "default": false
+                "default": true
             },
             {
                 "key": "EnableDailySummary",
                 "display_name": "Enable Daily Summary",
                 "type": "bool",
                 "help_text": "When enabled, Mattermost users will a receive a daily summary of their scheduled events in Microsoft Calendar. Users can choose when the summary will be sent to them.",
-                "default": false
+                "default": true
             }
         ]
     }


### PR DESCRIPTION
#### Summary

This PR explains the two scheduled jobs that are configurable to be enabled/disabled in the system console.

It also enables the jobs by default. Having an explicit step in the config to enable them is another option.

The additions can be found at the end of the README here https://github.com/mattermost/mattermost-plugin-mscalendar/blob/035e8606ab8f380595086bc9ebc4c723b1c2d2a1/README.md

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-mscalendar/issues/115