### PR TITLE
Add EE license check

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/gorilla/mux v1.7.3
 	github.com/jarcoal/httpmock v1.0.4
 	github.com/mattermost/mattermost-plugin-api v0.0.9
-	github.com/mattermost/mattermost-server/v5 v5.3.2-0.20200313113657-e2883bfe5f37
+	github.com/mattermost/mattermost-server/v5 v5.24.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1

--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -61,6 +61,11 @@ func NewWithEnv(env mscalendar.Env) *Plugin {
 }
 
 func (p *Plugin) OnActivate() error {
+	license := p.API.GetLicense()
+	if license == nil || !license.Features.EnterprisePlugins {
+		return errors.New("You need a Enterprise License to activate this plugin.")
+	}
+
 	p.initEnv(&p.env, "")
 	bundlePath, err := p.API.GetBundlePath()
 	if err != nil {


### PR DESCRIPTION
#### Summary
Add license check on plugin activate.

IMPORTANT: This require v5.24.0 of mattermost-server which is not yet released. Therefore, the package cannot be imported, and go.sum has not been properly updated. Probably this PR needs an update when v5.24.0 is in place.

#### Ticket Link
None

