### PR TITLE
[GH-153] Receive notifications of new events get's set to No even when I select Yes on login flow

### DIFF
--- a/server/mscalendar/welcomer.go
+++ b/server/mscalendar/welcomer.go
@@ -147,11 +147,8 @@ func (bot *mscBot) SetProperty(userID, propertyName string, value bool) error {
 	if propertyName == store.SubscribePropertyName {
 		if value {
 			m := New(bot.Env, userID)
-			l, err := m.ListRemoteSubscriptions()
-			if err != nil {
-				return err
-			}
-			if len(l) >= 1 {
+			_, err := m.LoadMyEventSubscription()
+			if err == nil { // Subscription found
 				return nil
 			}
 


### PR DESCRIPTION
#### Summary
Fixes the situation where some users do not set the "Receive notifications of new events" even if they clicked yes during the login.

#### Ticket Link
Fix #153 
