### PR TITLE
Change dep initialization order to avoid nil Logger

### DIFF
--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -126,9 +126,9 @@ func (p *Plugin) OnConfigurationChange() (err error) {
 		e.Config.MattermostSiteHostname = mattermostURL.Hostname()
 		e.Config.PluginURL = pluginURL
 		e.Config.PluginURLPath = pluginURLPath
-		e.Dependencies.Remote = remote.Makers[msgraph.Kind](e.Config, e.Logger)
 
 		e.bot = e.bot.WithConfig(stored.BotConfig)
+		e.Dependencies.Remote = remote.Makers[msgraph.Kind](e.Config, e.bot)
 
 		mscalendarBot := mscalendar.NewMSCalendarBot(e.bot, e.Env, pluginURL)
 


### PR DESCRIPTION
#### Summary

This is the only potential change I could find that could solve the intermittent issue of the Logger not being assigned to `Env.Dependencies.Remote`.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-mscalendar/issues/148

#### Analysis

The most recent panic Dylan has seen related to this is happening intermittently on subscription deletion in the remote client's `DeleteSubscription` method. I have not seen this happen myself. It seems that `Logger` assigned to the remote client is nil.

(Before this code change) Remote is assigned here. Logger is assigned at the bottom of this range.
https://github.com/mattermost/mattermost-plugin-mscalendar/blob/63e1af836a0dc2bffffb41f789743e053682e2d2/server/plugin/plugin.go#L129-L135

MakeClient creates a new client, and initializes it with a logger taken from a `Remote` instance.
https://github.com/mattermost/mattermost-plugin-mscalendar/blob/63e1af836a0dc2bffffb41f789743e053682e2d2/server/remote/msgraph/remote.go#L39-L49

Panic is happening on subscription deletion here. `c.Logger` must be nil. The full panic trace is not in the description of [the issue](https://github.com/mattermost/mattermost-plugin-mscalendar/issues/148), but Dylan and I looked at it together at the time.
https://github.com/mattermost/mattermost-plugin-mscalendar/blob/63e1af836a0dc2bffffb41f789743e053682e2d2/server/remote/msgraph/subscription.go#L49-L60

The first time we saw this occur was during `HandleWebhook`:
https://github.com/mattermost/mattermost-plugin-mscalendar/blob/63e1af836a0dc2bffffb41f789743e053682e2d2/server/remote/msgraph/handle_webhook.go#L29-L39