### PR TITLE
Fix panic when Daily Summary is nil for a user

### DIFF
--- a/server/mscalendar/daily_summary.go
+++ b/server/mscalendar/daily_summary.go
@@ -58,6 +58,14 @@ func (m *mscalendar) SetDailySummaryPostTime(user *User, timeStr string) (*store
 		return nil, err
 	}
 
+	if user.Settings.DailySummary == nil {
+		user.Settings.DailySummary = &store.DailySummaryUserSettings{
+			PostTime: "8:00AM",
+			Timezone: "Eastern Standard Time",
+			Enable:   false,
+		}
+	}
+
 	dsum := user.Settings.DailySummary
 	dsum.PostTime = timeStr
 	dsum.Timezone = timezone
@@ -73,6 +81,14 @@ func (m *mscalendar) SetDailySummaryEnabled(user *User, enable bool) (*store.Dai
 	err := m.Filter(withUserExpanded(user))
 	if err != nil {
 		return nil, err
+	}
+
+	if user.Settings.DailySummary == nil {
+		user.Settings.DailySummary = &store.DailySummaryUserSettings{
+			PostTime: "8:00AM",
+			Timezone: "Eastern Standard Time",
+			Enable:   false,
+		}
 	}
 
 	dsum := user.Settings.DailySummary
@@ -110,6 +126,10 @@ func (m *mscalendar) ProcessAllDailySummary(now time.Time) error {
 		byRemoteID[storeUser.Remote.ID] = storeUser
 
 		dsum := storeUser.Settings.DailySummary
+		if dsum == nil {
+			continue
+		}
+
 		shouldPost, shouldPostErr := shouldPostDailySummary(dsum, now)
 		if shouldPostErr != nil {
 			m.Logger.Warnf("Error posting daily summary for user %s. err=%v", user.MattermostUserID, shouldPostErr)
@@ -139,6 +159,10 @@ func (m *mscalendar) ProcessAllDailySummary(now time.Time) error {
 			m.Logger.Warnf("Error rendering user %s calendar. err=%s %s", user.MattermostUserID, res.Error.Code, res.Error.Message)
 		}
 		dsum := user.Settings.DailySummary
+		if dsum == nil {
+			// Should never reach this point
+			continue
+		}
 		postStr, err := views.RenderCalendarView(res.Events, dsum.Timezone)
 		if err != nil {
 			m.Logger.Warnf("Error rendering user %s calendar. err=%v", user.MattermostUserID, err)
@@ -172,7 +196,7 @@ func (m *mscalendar) GetDailySummaryForUser(user *User) (string, error) {
 }
 
 func shouldPostDailySummary(dsum *store.DailySummaryUserSettings, now time.Time) (bool, error) {
-	if !dsum.Enable {
+	if dsum == nil || !dsum.Enable {
 		return false, nil
 	}
 

--- a/server/mscalendar/daily_summary.go
+++ b/server/mscalendar/daily_summary.go
@@ -59,11 +59,7 @@ func (m *mscalendar) SetDailySummaryPostTime(user *User, timeStr string) (*store
 	}
 
 	if user.Settings.DailySummary == nil {
-		user.Settings.DailySummary = &store.DailySummaryUserSettings{
-			PostTime: "8:00AM",
-			Timezone: "Eastern Standard Time",
-			Enable:   false,
-		}
+		user.Settings.DailySummary = store.DefaultDailySummaryUserSettings()
 	}
 
 	dsum := user.Settings.DailySummary
@@ -84,11 +80,7 @@ func (m *mscalendar) SetDailySummaryEnabled(user *User, enable bool) (*store.Dai
 	}
 
 	if user.Settings.DailySummary == nil {
-		user.Settings.DailySummary = &store.DailySummaryUserSettings{
-			PostTime: "8:00AM",
-			Timezone: "Eastern Standard Time",
-			Enable:   false,
-		}
+		user.Settings.DailySummary = store.DefaultDailySummaryUserSettings()
 	}
 
 	dsum := user.Settings.DailySummary

--- a/server/store/setting_store.go
+++ b/server/store/setting_store.go
@@ -101,6 +101,14 @@ func (s *pluginStore) GetSetting(userID, settingID string) (interface{}, error) 
 }
 
 func (s *pluginStore) updateDailySummarySettingForUser(user *User, value interface{}) error {
+	if user.Settings.DailySummary == nil {
+		user.Settings.DailySummary = &DailySummaryUserSettings{
+			PostTime: "8:00AM",
+			Timezone: "Eastern Standard Time",
+			Enable:   false,
+		}
+	}
+
 	dsum := user.Settings.DailySummary
 
 	stringValue := value.(string)

--- a/server/store/setting_store.go
+++ b/server/store/setting_store.go
@@ -100,13 +100,16 @@ func (s *pluginStore) GetSetting(userID, settingID string) (interface{}, error) 
 	}
 }
 
+func DefaultDailySummaryUserSettings() *DailySummaryUserSettings {
+	return &DailySummaryUserSettings{
+		PostTime: "8:00AM",
+		Timezone: "Eastern Standard Time",
+		Enable:   false,
+	}
+}
 func (s *pluginStore) updateDailySummarySettingForUser(user *User, value interface{}) error {
 	if user.Settings.DailySummary == nil {
-		user.Settings.DailySummary = &DailySummaryUserSettings{
-			PostTime: "8:00AM",
-			Timezone: "Eastern Standard Time",
-			Enable:   false,
-		}
+		user.Settings.DailySummary = DefaultDailySummaryUserSettings()
 	}
 
 	dsum := user.Settings.DailySummary


### PR DESCRIPTION
#### Summary
There seems to be a panic in master that happens when the daily summary settings are set to nil. This should never happen, but maybe a weird status in the system is triggering this.

This PR makes sure the daily summary setting is set by adding a default in every point it is present.

Another solution could be remove the indirection and trust the go defaults.

#### Ticket Link
None
