### PR TITLE
Add back build info

### DIFF
--- a/build/custom.mk
+++ b/build/custom.mk
@@ -5,7 +5,17 @@ endif
 
 LDFLAGS += -X "github.com/mattermost/mattermost-plugin-mscalendar/server/utils/telemetry.rudderWriteKey=$(MM_RUDDER_WRITE_KEY)"
 
-## Generates mock golang interfaces for testing
+# Build info
+BUILD_DATE = $(shell date -u)
+BUILD_HASH = $(shell git rev-parse HEAD)
+BUILD_HASH_SHORT = $(shell git rev-parse --short HEAD)
+LDFLAGS += -X "main.BuildDate=$(BUILD_DATE)"
+LDFLAGS += -X "main.BuildHash=$(BUILD_HASH)"
+LDFLAGS += -X "main.BuildHashShort=$(BUILD_HASH_SHORT)"
+
+GO_BUILD_FLAGS = -ldflags '$(LDFLAGS)'
+
+# Generates mock golang interfaces for testing
 mock:
 ifneq ($(HAS_SERVER),)
 	go install github.com/golang/mock/mockgen


### PR DESCRIPTION
#### Summary
Add back build info for `/mscalendar info`. This was broken in https://github.com/mattermost/mattermost-plugin-mscalendar/pull/196.

![Screenshot from 2021-09-27 16-01-03](https://user-images.githubusercontent.com/16541325/134924671-5a3c26e9-b02c-4555-841e-f35de776a030.png)


#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-mscalendar/issues/231