### PR TITLE
[fix] Remove lock missing txt

### DIFF
--- a/lock-missing.txt
+++ b/lock-missing.txt
@@ -1,1 +1,0 @@
-mattermost-plugin-mscalendar


### PR DESCRIPTION
#### Summary
Remove redundant file `lock-missing.txt`

