### PR TITLE
Bump version to 1.2.1

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -4,9 +4,9 @@
     "description": "Microsoft Calendar Integration",
     "homepage_url": "https://mattermost.gitbook.io/plugin-mscalendar",
     "support_url": "https://github.com/mattermost/mattermost-plugin-mscalendar/issues",
-    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-mscalendar/releases/tag/v1.2.0",
+    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-mscalendar/releases/tag/v1.2.1",
     "icon_path": "assets/profile.svg",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "min_server_version": "5.37.0",
     "server": {
         "executables": {

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -7,5 +7,5 @@ var manifest = struct {
 	Version string
 }{
 	ID:      "com.mattermost.mscalendar",
-	Version: "1.2.0",
+	Version: "1.2.1",
 }


### PR DESCRIPTION
#### Summary

- https://github.com/mattermost/mattermost-plugin-mscalendar/pull/254

Currently making this so we can create an RC build for debugging. See https://community.mattermost.com/private-core/pl/aet78fsxwt8ntrn74tefzztorc and https://community.mattermost.com/core/pl/gtyhjtzgmtdb7efqa9cwuzub9w