### PR TITLE
[GCAL] Refactor Microsoft Calendar references to provider references

### DIFF
--- a/providers/gcal.go
+++ b/providers/gcal.go
@@ -1,11 +1,14 @@
 package providers
 
-import "github.com/mattermost/mattermost-plugin-mscalendar/server/config"
+import (
+	"github.com/mattermost/mattermost-plugin-mscalendar/server/config"
+	"github.com/mattermost/mattermost-plugin-mscalendar/server/remote/gcal"
+)
 
 const (
-	ProviderGCal            = "gcal"
+	ProviderGCal            = gcal.Kind
 	ProviderGCalDisplayName = "Google Calendar"
-	ProviderGCalRepository  = ""
+	ProviderGCalRepository  = ProviderMSCalendarRepository
 )
 
 func GetGcalProviderConfig() *config.ProviderConfig {

--- a/providers/mscalendar.go
+++ b/providers/mscalendar.go
@@ -1,11 +1,14 @@
 package providers
 
-import "github.com/mattermost/mattermost-plugin-mscalendar/server/config"
+import (
+	"github.com/mattermost/mattermost-plugin-mscalendar/server/config"
+	"github.com/mattermost/mattermost-plugin-mscalendar/server/remote/msgraph"
+)
 
 const (
-	ProviderMSCalendar            = "mscalendar"
+	ProviderMSCalendar            = msgraph.Kind
 	ProviderMSCalendarDisplayName = "Microsoft Calendar"
-	ProviderMSCalendarRepository  = ""
+	ProviderMSCalendarRepository  = "mattermost-plugin-mscalendar"
 )
 
 func GetMSCalendarProviderConfig() *config.ProviderConfig {

--- a/server/command/daily_summary.go
+++ b/server/command/daily_summary.go
@@ -3,17 +3,19 @@ package command
 import (
 	"fmt"
 
+	"github.com/mattermost/mattermost-plugin-mscalendar/server/config"
 	"github.com/mattermost/mattermost-plugin-mscalendar/server/store"
 )
 
-const dailySummaryHelp = "### Daily summary commands:\n" +
-	"`/mscalendar summary view` - View your daily summary\n" +
-	"`/mscalendar summary settings` - View your settings for the daily summary\n" +
-	"`/mscalendar summary time 8:00AM` - Set the time you would like to receive your daily summary\n" +
-	"`/mscalendar summary enable` - Enable your daily summary\n" +
-	"`/mscalendar summary disable` - Disable your daily summary"
-
-const dailySummarySetTimeErrorMessage = "Please enter a time, for example:\n`/mscalendar summary time 8:00AM`"
+var (
+	dailySummaryHelp = "### Daily summary commands:\n" +
+		fmt.Sprintf("`/%s summary view` - View your daily summary\n", config.Provider.CommandTrigger) +
+		fmt.Sprintf("`/%s summary settings` - View your settings for the daily summary\n", config.Provider.CommandTrigger) +
+		fmt.Sprintf("`/%s summary time 8:00AM` - Set the time you would like to receive your daily summary\n", config.Provider.CommandTrigger) +
+		fmt.Sprintf("`/%s summary enable` - Enable your daily summary\n", config.Provider.CommandTrigger) +
+		fmt.Sprintf("`/%s summary disable` - Disable your daily summary", config.Provider.CommandTrigger)
+	dailySummarySetTimeErrorMessage = fmt.Sprintf("Please enter a time, for example:\n`/%s summary time 8:00AM`", config.Provider.CommandTrigger)
+)
 
 func (c *Command) dailySummary(parameters ...string) (string, bool, error) {
 	if len(parameters) == 0 {
@@ -71,7 +73,7 @@ func dailySummaryResponse(dsum *store.DailySummaryUserSettings) string {
 
 	enableStr := ""
 	if !dsum.Enable {
-		enableStr = ", but is disabled. Enable it with `/mscalendar summary enable`"
+		enableStr = fmt.Sprintf(", but is disabled. Enable it with `/%s summary enable`", config.Provider.CommandTrigger)
 	}
 	return fmt.Sprintf("Your daily summary is configured to show at %s %s%s.", dsum.PostTime, dsum.Timezone, enableStr)
 }

--- a/server/command/info.go
+++ b/server/command/info.go
@@ -9,10 +9,10 @@ import (
 	"github.com/mattermost/mattermost-plugin-mscalendar/server/config"
 )
 
-// REVIEW: hardcoded "microsoft"
 func (c *Command) info(parameters ...string) (string, bool, error) {
-	resp := fmt.Sprintf("Mattermost Microsoft Calendar plugin version: %s, "+
+	resp := fmt.Sprintf("Mattermost %s plugin version: %s, "+
 		"[%s](https://github.com/mattermost/%s/commit/%s), built %s\n",
+		c.Config.Provider.DisplayName,
 		c.Config.PluginVersion,
 		c.Config.BuildHashShort,
 		config.Provider.Repository,

--- a/server/mscalendar/calendar.go
+++ b/server/mscalendar/calendar.go
@@ -72,7 +72,7 @@ func (m *mscalendar) CreateEvent(user *User, event *remote.Event, mattermostUser
 		_, err := m.Store.LoadUser(mattermostUserID)
 		if err != nil {
 			if err.Error() == "not found" {
-				_, err = m.Poster.DM(mattermostUserID, "You have been invited to an Microsoft Outlook calendar event but have not linked your account.  Feel free to join us by connecting your Microsoft Outlook account using `/mscalendar connect`")
+				_, err = m.Poster.DM(mattermostUserID, "You have been invited to a %s event but have not linked your account.  Feel free to join us by connecting your %s account using `/mscalendar connect`", m.Provider.DisplayName, m.Provider.DisplayName)
 				if err != nil {
 					m.Logger.Warnf("CreateEvent error creating DM. err=%v", err)
 					continue

--- a/server/mscalendar/calendar.go
+++ b/server/mscalendar/calendar.go
@@ -72,7 +72,7 @@ func (m *mscalendar) CreateEvent(user *User, event *remote.Event, mattermostUser
 		_, err := m.Store.LoadUser(mattermostUserID)
 		if err != nil {
 			if err.Error() == "not found" {
-				_, err = m.Poster.DM(mattermostUserID, "You have been invited to a %s event but have not linked your account.  Feel free to join us by connecting your %s account using `/mscalendar connect`", m.Provider.DisplayName, m.Provider.DisplayName)
+				_, err = m.Poster.DM(mattermostUserID, "You have been invited to a %s event but have not linked your account.  Feel free to join us by connecting your %s account using `/%s connect`", m.Provider.DisplayName, m.Provider.DisplayName, m.Provider.CommandTrigger)
 				if err != nil {
 					m.Logger.Warnf("CreateEvent error creating DM. err=%v", err)
 					continue

--- a/server/mscalendar/settings_daily_summary.go
+++ b/server/mscalendar/settings_daily_summary.go
@@ -136,7 +136,7 @@ func (s *dailySummarySetting) GetSlackAttachments(userID, settingHandler string,
 
 	timezone, err := s.getTimezone(userID)
 	if err != nil {
-		return nil, fmt.Errorf("could not load the timezone from Microsoft. err=%v", err)
+		return nil, fmt.Errorf("could not load the timezone. err=%v", err)
 	}
 	fullTime = fullTime + " " + timezone
 

--- a/server/mscalendar/user.go
+++ b/server/mscalendar/user.go
@@ -61,7 +61,7 @@ func (m *mscalendar) ExpandRemoteUser(user *User) error {
 	if user.User == nil {
 		storedUser, err := m.Store.LoadUser(user.MattermostUserID)
 		if err != nil {
-			return errors.Wrap(err, "It looks like your Mattermost account is not connected to a Microsoft account. Please connect your account using `/mscalendar connect`.") //nolint:revive
+			return errors.Wrapf(err, "It looks like your Mattermost account is not connected to %s. Please connect your account using `/%s connect`.", m.Provider.DisplayName, m.Provider.CommandTrigger) //nolint:revive
 		}
 		user.User = storedUser
 	}

--- a/server/mscalendar/welcome_flow.go
+++ b/server/mscalendar/welcome_flow.go
@@ -1,6 +1,9 @@
 package mscalendar
 
 import (
+	"fmt"
+
+	"github.com/mattermost/mattermost-plugin-mscalendar/server/config"
 	"github.com/mattermost/mattermost-plugin-mscalendar/server/store"
 	"github.com/mattermost/mattermost-plugin-mscalendar/server/utils/bot"
 	"github.com/mattermost/mattermost-plugin-mscalendar/server/utils/flow"
@@ -94,7 +97,7 @@ func (wf *WelcomeFlow) makeSteps() {
 		FalseResponseMessage: "Great, you will not receive any notification for upcoming events.",
 	}, &flow.EmptyStep{
 		Title:   "Daily Summary",
-		Message: "Remember that you can set-up a daily summary by typing `/mscalendar summary time 8:00AM`.",
+		Message: fmt.Sprintf("Remember that you can set-up a daily summary by typing `/%s summary time 8:00AM`.", config.Provider.CommandTrigger),
 	})
 
 	wf.steps = steps

--- a/server/mscalendar/welcome_flow.go
+++ b/server/mscalendar/welcome_flow.go
@@ -53,7 +53,7 @@ func (wf *WelcomeFlow) makeSteps() {
 	steps := []flow.Step{}
 	steps = append(steps, &flow.SimpleStep{
 		Title:                "Update Status",
-		Message:              "Would you like your Mattermost status to be automatically updated at the time of your Microsoft Calendar events?",
+		Message:              "Would you like your Mattermost status to be automatically updated at the time of your events?",
 		PropertyName:         store.UpdateStatusPropertyName,
 		TrueButtonMessage:    "Yes - Update my status",
 		FalseButtonMessage:   "No - Don't update my status",

--- a/server/mscalendar/welcomer.go
+++ b/server/mscalendar/welcomer.go
@@ -31,9 +31,7 @@ type mscBot struct {
 }
 
 const (
-	// REVIEW: "microsoft" referenced here
-	WelcomeMessage = `Welcome to the Microsoft Calendar plugin.
-	[Click here to link your account.](%s/oauth2/connect)`
+	WelcomeMessage = `Welcome to the %s plugin. [Click here to link your account.](%s/oauth2/connect)`
 )
 
 func (m *mscalendar) Welcome(userID string) error {
@@ -111,7 +109,7 @@ func (bot *mscBot) WelcomeFlowEnd(userID string) {
 
 func (bot *mscBot) newConnectAttachment() *model.SlackAttachment {
 	title := "Connect"
-	text := fmt.Sprintf(WelcomeMessage, bot.pluginURL)
+	text := fmt.Sprintf(WelcomeMessage, bot.Provider.DisplayName, bot.pluginURL)
 	sa := model.SlackAttachment{
 		Title:    title,
 		Text:     text,
@@ -123,8 +121,7 @@ func (bot *mscBot) newConnectAttachment() *model.SlackAttachment {
 
 func (bot *mscBot) newConnectedAttachment(userLogin string) *model.SlackAttachment {
 	title := "Connect"
-	// REVIEW: "microsoft" referenced here
-	text := ":tada: Congratulations! Your microsoft account (*" + userLogin + "*) has been connected to Mattermost."
+	text := ":tada: Congratulations! Your " + bot.Provider.DisplayName + " account (*" + userLogin + "*) has been connected to Mattermost."
 	return &model.SlackAttachment{
 		Title:    title,
 		Text:     text,

--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -25,7 +25,6 @@ import (
 	"github.com/mattermost/mattermost-plugin-mscalendar/server/jobs"
 	"github.com/mattermost/mattermost-plugin-mscalendar/server/mscalendar"
 	"github.com/mattermost/mattermost-plugin-mscalendar/server/remote"
-	"github.com/mattermost/mattermost-plugin-mscalendar/server/remote/gcal"
 	"github.com/mattermost/mattermost-plugin-mscalendar/server/store"
 	"github.com/mattermost/mattermost-plugin-mscalendar/server/telemetry"
 	"github.com/mattermost/mattermost-plugin-mscalendar/server/tracker"
@@ -173,7 +172,7 @@ func (p *Plugin) OnConfigurationChange() (err error) {
 		e.Config.PluginURLPath = pluginURLPath
 
 		e.bot = e.bot.WithConfig(stored.Config)
-		e.Dependencies.Remote = remote.Makers[gcal.Kind](e.Config, e.bot)
+		e.Dependencies.Remote = remote.Makers[config.Provider.Name](e.Config, e.bot)
 
 		// REVIEW: need to make this provider agnostic terminology
 		mscalendarBot := mscalendar.NewMSCalendarBot(e.bot, e.Env, pluginURL)
@@ -209,7 +208,7 @@ func (p *Plugin) OnConfigurationChange() (err error) {
 		}
 
 		e.httpHandler = httputils.NewHandler()
-		oauth2connect.Init(e.httpHandler, mscalendar.NewOAuth2App(e.Env))
+		oauth2connect.Init(e.httpHandler, mscalendar.NewOAuth2App(e.Env), config.Provider)
 		flow.Init(e.httpHandler, welcomeFlow, mscalendarBot)
 		settingspanel.Init(e.httpHandler, e.Dependencies.SettingsPanel)
 		api.Init(e.httpHandler, e.Env, e.notificationProcessor)

--- a/server/utils/oauth2connect/oauth2.go
+++ b/server/utils/oauth2connect/oauth2.go
@@ -4,8 +4,6 @@
 package oauth2connect
 
 import (
-	"net/http"
-
 	"github.com/mattermost/mattermost-plugin-mscalendar/server/config"
 	"github.com/mattermost/mattermost-plugin-mscalendar/server/utils/httputils"
 )
@@ -29,7 +27,5 @@ func Init(h *httputils.Handler, app App, providerConfig config.ProviderConfig) {
 
 	oauth2Router := h.Router.PathPrefix("/oauth2").Subrouter()
 	oauth2Router.HandleFunc("/connect", oa.oauth2Connect).Methods("GET")
-	oauth2Router.HandleFunc("/complete", func(w http.ResponseWriter, r *http.Request) {
-		oa.oauth2Complete(w, r, oa.provider.DisplayName)
-	}).Methods("GET")
+	oauth2Router.HandleFunc("/complete", oa.oauth2Complete).Methods("GET")
 }

--- a/server/utils/oauth2connect/oauth2.go
+++ b/server/utils/oauth2connect/oauth2.go
@@ -4,6 +4,9 @@
 package oauth2connect
 
 import (
+	"net/http"
+
+	"github.com/mattermost/mattermost-plugin-mscalendar/server/config"
 	"github.com/mattermost/mattermost-plugin-mscalendar/server/utils/httputils"
 )
 
@@ -14,14 +17,19 @@ type App interface {
 
 type oa struct {
 	app App
+
+	provider config.ProviderConfig
 }
 
-func Init(h *httputils.Handler, app App) {
+func Init(h *httputils.Handler, app App, providerConfig config.ProviderConfig) {
 	oa := &oa{
-		app: app,
+		app:      app,
+		provider: providerConfig,
 	}
 
 	oauth2Router := h.Router.PathPrefix("/oauth2").Subrouter()
 	oauth2Router.HandleFunc("/connect", oa.oauth2Connect).Methods("GET")
-	oauth2Router.HandleFunc("/complete", oa.oauth2Complete).Methods("GET")
+	oauth2Router.HandleFunc("/complete", func(w http.ResponseWriter, r *http.Request) {
+		oa.oauth2Complete(w, r, oa.provider.DisplayName)
+	}).Methods("GET")
 }

--- a/server/utils/oauth2connect/oauth2_complete.go
+++ b/server/utils/oauth2connect/oauth2_complete.go
@@ -4,12 +4,13 @@
 package oauth2connect
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/mattermost/mattermost-plugin-mscalendar/server/utils/httputils"
 )
 
-func (oa *oa) oauth2Complete(w http.ResponseWriter, r *http.Request) {
+func (oa *oa) oauth2Complete(w http.ResponseWriter, r *http.Request, providerDisplayName string) {
 	mattermostUserID := r.Header.Get("Mattermost-User-ID")
 	if mattermostUserID == "" {
 		http.Error(w, "Not authorized", http.StatusUnauthorized)
@@ -28,7 +29,6 @@ func (oa *oa) oauth2Complete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// REVIEW "microsoft" is hardcoded
 	html := `
 		<!DOCTYPE html>
 		<html>
@@ -38,11 +38,11 @@ func (oa *oa) oauth2Complete(w http.ResponseWriter, r *http.Request) {
 				</script>
 			</head>
 			<body>
-				<p>Completed connecting to Microsoft Calendar. Please close this window.</p>
+				<p>Completed connecting to %s. Please close this window.</p>
 			</body>
 		</html>
 		`
 
 	w.Header().Set("Content-Type", "text/html")
-	w.Write([]byte(html))
+	w.Write([]byte(fmt.Sprintf(html, providerDisplayName)))
 }

--- a/server/utils/oauth2connect/oauth2_complete.go
+++ b/server/utils/oauth2connect/oauth2_complete.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mattermost/mattermost-plugin-mscalendar/server/utils/httputils"
 )
 
-func (oa *oa) oauth2Complete(w http.ResponseWriter, r *http.Request, providerDisplayName string) {
+func (oa *oa) oauth2Complete(w http.ResponseWriter, r *http.Request) {
 	mattermostUserID := r.Header.Get("Mattermost-User-ID")
 	if mattermostUserID == "" {
 		http.Error(w, "Not authorized", http.StatusUnauthorized)
@@ -44,5 +44,5 @@ func (oa *oa) oauth2Complete(w http.ResponseWriter, r *http.Request, providerDis
 		`
 
 	w.Header().Set("Content-Type", "text/html")
-	w.Write([]byte(fmt.Sprintf(html, providerDisplayName)))
+	w.Write([]byte(fmt.Sprintf(html, oa.provider.DisplayName)))
 }


### PR DESCRIPTION
#### Summary

Refactor to use the `config.ProviderConfig` data to display text in the plugin, mainly the display name and the command trigger in help text around the commands and events.

#### Ticket Link

