### PR TITLE
[GCAL] Move configuration readyness logic to remotes

### DIFF
--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -71,10 +71,8 @@ func (p *Plugin) OnActivate() error {
 		return errors.WithMessage(err, "failed to load plugin configuration")
 	}
 
-	if stored.OAuth2Authority == "" ||
-		stored.OAuth2ClientID == "" ||
-		stored.OAuth2ClientSecret == "" {
-		return errors.New("failed to configure: OAuth2 credentials to be set in the config")
+	if errConfig := p.env.Remote.CheckConfiguration(stored); errConfig != nil {
+		return errors.Wrap(errConfig, "failed to configure: ")
 	}
 
 	p.initEnv(&p.env, "")

--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -72,7 +72,7 @@ func (p *Plugin) OnActivate() error {
 	}
 
 	if errConfig := p.env.Remote.CheckConfiguration(stored); errConfig != nil {
-		return errors.Wrap(errConfig, "failed to configure: ")
+		return errors.Wrap(errConfig, "failed to configure")
 	}
 
 	p.initEnv(&p.env, "")

--- a/server/remote/gcal/remote.go
+++ b/server/remote/gcal/remote.go
@@ -76,5 +76,9 @@ func (r *impl) CheckConfiguration(cfg config.StoredConfig) error {
 		return fmt.Errorf("OAuth2 credentials to be set in the config")
 	}
 
+	if cfg.EncryptionKey == "" {
+		return fmt.Errorf("encryption key cannot be empty")
+	}
+
 	return nil
 }

--- a/server/remote/gcal/remote.go
+++ b/server/remote/gcal/remote.go
@@ -5,6 +5,7 @@ package gcal
 
 import (
 	"context"
+	"fmt"
 
 	"golang.org/x/oauth2"
 	"google.golang.org/api/calendar/v3"
@@ -68,4 +69,12 @@ func (r *impl) NewOAuth2Config() *oauth2.Config {
 		},
 		Endpoint: google.Endpoint,
 	}
+}
+
+func (r *impl) CheckConfiguration(cfg config.StoredConfig) error {
+	if cfg.OAuth2ClientID == "" || cfg.OAuth2ClientSecret == "" {
+		return fmt.Errorf("OAuth2 credentials to be set in the config")
+	}
+
+	return nil
 }

--- a/server/remote/mock_remote/mock_remote.go
+++ b/server/remote/mock_remote/mock_remote.go
@@ -10,6 +10,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	config "github.com/mattermost/mattermost-plugin-mscalendar/server/config"
 	remote "github.com/mattermost/mattermost-plugin-mscalendar/server/remote"
 	oauth2 "golang.org/x/oauth2"
 )
@@ -35,6 +36,20 @@ func NewMockRemote(ctrl *gomock.Controller) *MockRemote {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRemote) EXPECT() *MockRemoteMockRecorder {
 	return m.recorder
+}
+
+// CheckConfiguration mocks base method.
+func (m *MockRemote) CheckConfiguration(arg0 config.StoredConfig) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckConfiguration", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CheckConfiguration indicates an expected call of CheckConfiguration.
+func (mr *MockRemoteMockRecorder) CheckConfiguration(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckConfiguration", reflect.TypeOf((*MockRemote)(nil).CheckConfiguration), arg0)
 }
 
 // HandleWebhook mocks base method.

--- a/server/remote/msgraph/remote.go
+++ b/server/remote/msgraph/remote.go
@@ -5,6 +5,7 @@ package msgraph
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"golang.org/x/oauth2"
@@ -84,4 +85,12 @@ func (r *impl) NewOAuth2Config() *oauth2.Config {
 		},
 		Endpoint: microsoft.AzureADEndpoint(r.conf.OAuth2Authority),
 	}
+}
+
+func (r *impl) CheckConfiguration(cfg config.StoredConfig) error {
+	if cfg.OAuth2ClientID == "" || cfg.OAuth2ClientSecret == "" || cfg.OAuth2Authority == "" {
+		return fmt.Errorf("OAuth2 credentials to be set in the config")
+	}
+
+	return nil
 }

--- a/server/remote/remote.go
+++ b/server/remote/remote.go
@@ -21,6 +21,7 @@ type Remote interface {
 	MakeSuperuserClient(ctx context.Context) (Client, error)
 	NewOAuth2Config() *oauth2.Config
 	HandleWebhook(http.ResponseWriter, *http.Request) []*Notification
+	CheckConfiguration(configuration config.StoredConfig) error
 }
 
 var Makers = map[string]func(*config.Config, bot.Logger) Remote{}


### PR DESCRIPTION
#### Summary

Refactored the logic that checks for the correct configuration to the remotes instead of doing it in the main plugin load, since each remote has different requirements now.
