### PR TITLE
#WIP [GCAL/MSCAL] Revoke access token / refresh token on disconnect

### DIFF
--- a/server/remote/auth.go
+++ b/server/remote/auth.go
@@ -1,0 +1,8 @@
+package remote
+
+// Session represents an user authenticated with the plugin and the minimal data we need to revoke
+// the sessions from our side.
+type Session struct {
+	RemoteID    string
+	AccessToken string
+}

--- a/server/remote/client.go
+++ b/server/remote/client.go
@@ -19,6 +19,7 @@ type Client interface {
 
 type Core interface {
 	GetMe() (*User, error)
+	RevokeSession(session Session) error
 }
 
 type Calendars interface {

--- a/server/remote/gcal/auth.go
+++ b/server/remote/gcal/auth.go
@@ -1,0 +1,40 @@
+package gcal
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/pkg/errors"
+
+	"github.com/mattermost/mattermost-plugin-mscalendar/server/remote"
+	"github.com/mattermost/mattermost-plugin-mscalendar/server/utils/bot"
+)
+
+func (c *client) RevokeSession(session remote.Session) error {
+	resp, err := http.PostForm("https://oauth2.googleapis.com/revoke", url.Values{
+		"token": []string{session.AccessToken},
+	})
+	if err != nil {
+		return errors.Wrap(err, "error revoking user accesss token")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		var body []byte
+		var err error
+
+		body, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return errors.Wrap(err, "error reading revoke response body")
+		}
+
+		c.Logger.With(bot.LogContext{
+			"response": string(body),
+		}).Errorf("error revoking token")
+		return fmt.Errorf("unsuccessful revoke request")
+	}
+
+	return nil
+}

--- a/server/remote/mock_remote/mock_client.go
+++ b/server/remote/mock_remote/mock_client.go
@@ -347,18 +347,18 @@ func (mr *MockClientMockRecorder) RenewSubscription(arg0, arg1, arg2 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenewSubscription", reflect.TypeOf((*MockClient)(nil).RenewSubscription), arg0, arg1, arg2)
 }
 
-// RevokeToken mocks base method.
-func (m *MockClient) RevokeToken(arg0 string) error {
+// RevokeSession mocks base method.
+func (m *MockClient) RevokeSession(arg0 remote.Session) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RevokeToken", arg0)
+	ret := m.ctrl.Call(m, "RevokeSession", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// RevokeToken indicates an expected call of RevokeToken.
-func (mr *MockClientMockRecorder) RevokeToken(arg0 interface{}) *gomock.Call {
+// RevokeSession indicates an expected call of RevokeSession.
+func (mr *MockClientMockRecorder) RevokeSession(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeToken", reflect.TypeOf((*MockClient)(nil).RevokeToken), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeSession", reflect.TypeOf((*MockClient)(nil).RevokeSession), arg0)
 }
 
 // TentativelyAcceptEvent mocks base method.

--- a/server/remote/mock_remote/mock_client.go
+++ b/server/remote/mock_remote/mock_client.go
@@ -347,6 +347,20 @@ func (mr *MockClientMockRecorder) RenewSubscription(arg0, arg1, arg2 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenewSubscription", reflect.TypeOf((*MockClient)(nil).RenewSubscription), arg0, arg1, arg2)
 }
 
+// RevokeToken mocks base method.
+func (m *MockClient) RevokeToken(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RevokeToken", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RevokeToken indicates an expected call of RevokeToken.
+func (mr *MockClientMockRecorder) RevokeToken(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeToken", reflect.TypeOf((*MockClient)(nil).RevokeToken), arg0)
+}
+
 // TentativelyAcceptEvent mocks base method.
 func (m *MockClient) TentativelyAcceptEvent(arg0, arg1 string) error {
 	m.ctrl.T.Helper()

--- a/server/remote/msgraph/auth.go
+++ b/server/remote/msgraph/auth.go
@@ -1,0 +1,18 @@
+package msgraph
+
+import (
+	"github.com/mattermost/mattermost-plugin-mscalendar/server/remote"
+	"github.com/pkg/errors"
+	msgraph "github.com/yaegashi/msgraph.go/v1.0"
+)
+
+func (c *client) RevokeSession(session remote.Session) error {
+	_, err := c.rbuilder.Users().ID("").
+		RevokeSignInSessions(&msgraph.UserRevokeSignInSessionsRequestParameter{}).
+		Request().Post(c.ctx)
+	if err != nil {
+		return errors.Wrap(err, "msgraph RevokeToken")
+	}
+
+	return nil
+}


### PR DESCRIPTION
#### Summary

Adds the logic to revoke access tokens (gcal) and refresh tokens (msgraph, needs testing) when the user disconnects its account.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-53852
