### PR TITLE
[GCAL] Fix event notifications not working due to missing scope permissions plus internal state

### DIFF
--- a/server/mscalendar/availability.go
+++ b/server/mscalendar/availability.go
@@ -167,7 +167,7 @@ func (m *mscalendar) syncUsers(userIndex store.UserIndex, fetchIndividually bool
 		return err.Error(), syncJobSummary, errors.Wrapf(err, "error retrieving users to sync (individually=%v)", fetchIndividually)
 	}
 
-	m.deliverReminders(users, calendarViews)
+	m.deliverReminders(users, calendarViews, fetchIndividually)
 	out, numberOfUsersStatusChanged, numberOfUsersFailedStatusChanged, err := m.setUserStatuses(users, calendarViews)
 	if err != nil {
 		return "", syncJobSummary, errors.Wrap(err, "error setting the user statuses")
@@ -179,7 +179,7 @@ func (m *mscalendar) syncUsers(userIndex store.UserIndex, fetchIndividually bool
 	return out, syncJobSummary, nil
 }
 
-func (m *mscalendar) deliverReminders(users []*store.User, calendarViews []*remote.ViewCalendarResponse) {
+func (m *mscalendar) deliverReminders(users []*store.User, calendarViews []*remote.ViewCalendarResponse, fetchIndividually bool) {
 	numberOfLogs := 0
 	toNotify := []*store.User{}
 	for _, u := range users {
@@ -212,7 +212,15 @@ func (m *mscalendar) deliverReminders(users []*store.User, calendarViews []*remo
 		}
 
 		mattermostUserID := usersByRemoteID[view.RemoteUserID].MattermostUserID
-		m.notifyUpcomingEvents(mattermostUserID, view.Events)
+		if fetchIndividually {
+			engine, err := m.FilterCopy(withActingUser(user.MattermostUserID))
+			if err != nil {
+				m.Logger.With(bot.LogContext{"err": err}).Errorf("error getting engine for user")
+			}
+			engine.notifyUpcomingEvents(mattermostUserID, view.Events)
+		} else {
+			m.notifyUpcomingEvents(mattermostUserID, view.Events)
+		}
 	}
 }
 
@@ -486,6 +494,7 @@ func (m *mscalendar) GetCalendarViews(users []*store.User) ([]*remote.ViewCalend
 }
 
 func (m *mscalendar) notifyUpcomingEvents(mattermostUserID string, events []*remote.Event) {
+	m.Logger.With(bot.LogContext{"mm_id": mattermostUserID, "events": *events[0]}).Warnf("notifyUpconmingEvents")
 	var timezone string
 	for _, event := range events {
 		if event.IsCancelled {

--- a/server/mscalendar/availability.go
+++ b/server/mscalendar/availability.go
@@ -216,6 +216,7 @@ func (m *mscalendar) deliverReminders(users []*store.User, calendarViews []*remo
 			engine, err := m.FilterCopy(withActingUser(user.MattermostUserID))
 			if err != nil {
 				m.Logger.With(bot.LogContext{"err": err}).Errorf("error getting engine for user")
+				continue
 			}
 			engine.notifyUpcomingEvents(mattermostUserID, view.Events)
 		} else {

--- a/server/mscalendar/availability.go
+++ b/server/mscalendar/availability.go
@@ -494,7 +494,6 @@ func (m *mscalendar) GetCalendarViews(users []*store.User) ([]*remote.ViewCalend
 }
 
 func (m *mscalendar) notifyUpcomingEvents(mattermostUserID string, events []*remote.Event) {
-	m.Logger.With(bot.LogContext{"mm_id": mattermostUserID, "events": *events[0]}).Warnf("notifyUpconmingEvents")
 	var timezone string
 	for _, event := range events {
 		if event.IsCancelled {

--- a/server/remote/gcal/remote.go
+++ b/server/remote/gcal/remote.go
@@ -62,7 +62,7 @@ func (r *impl) NewOAuth2Config() *oauth2.Config {
 		ClientSecret: r.conf.OAuth2ClientSecret,
 		RedirectURL:  r.conf.PluginURL + config.FullPathOAuth2Redirect,
 		Scopes: []string{
-			calendar.CalendarEventsScope,           // Read and create events
+			calendar.CalendarScope,                 // Read and create events and calendar
 			calendar.CalendarSettingsReadonlyScope, // Read the user timezone
 			people.UserinfoEmailScope,              // Get the user email address
 			people.UserinfoProfileScope,            // Get user ID and display name


### PR DESCRIPTION
#### Summary
- In order to retrieve the timezone we need `CalendarScope`. We will need it later to retrieve calendars anyway.
- For `deliverReminders` to work properly, since we do not have a superuser credential around (and we now use the `FilterCopy` logic) we had to change it's internal logic as well.

