### PR TITLE
[GCAL] Unsubscriptions

### DIFF
--- a/server/mscalendar/availability.go
+++ b/server/mscalendar/availability.go
@@ -494,7 +494,6 @@ func (m *mscalendar) GetCalendarViews(users []*store.User) ([]*remote.ViewCalend
 }
 
 func (m *mscalendar) notifyUpcomingEvents(mattermostUserID string, events []*remote.Event) {
-	m.Logger.With(bot.LogContext{"mm_id": mattermostUserID, "events": *events[0]}).Warnf("notifyUpconmingEvents")
 	var timezone string
 	for _, event := range events {
 		if event.IsCancelled {

--- a/server/mscalendar/mock_mscalendar/mock_mscalendar.go
+++ b/server/mscalendar/mock_mscalendar/mock_mscalendar.go
@@ -179,7 +179,7 @@ func (mr *MockMSCalendarMockRecorder) DeleteMyEventSubscription() *gomock.Call {
 }
 
 // DeleteOrphanedSubscription mocks base method.
-func (m *MockMSCalendar) DeleteOrphanedSubscription(arg0 string) error {
+func (m *MockMSCalendar) DeleteOrphanedSubscription(arg0 *store.Subscription) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteOrphanedSubscription", arg0)
 	ret0, _ := ret[0].(error)

--- a/server/mscalendar/notification.go
+++ b/server/mscalendar/notification.go
@@ -140,7 +140,7 @@ func (processor *notificationProcessor) processNotification(n *remote.Notificati
 	// REVIEW: depends on lifecycle of subscriptions. its always false for gcal. set to true in msgraph client here https://github.com/mattermost/mattermost-plugin-mscalendar/blob/9ed5ee6e2141e7e6f32a5a80d7a20ab0881c8586/server/remote/msgraph/handle_webhook.go#L77-L80
 	if n.RecommendRenew {
 		var renewed *remote.Subscription
-		renewed, err = client.RenewSubscription(processor.Config.GetNotificationURL(), sub.Remote.CreatorID, n.SubscriptionID)
+		renewed, err = client.RenewSubscription(processor.Config.GetNotificationURL(), sub.Remote.CreatorID, n.Subscription)
 		if err != nil {
 			return err
 		}

--- a/server/remote/client.go
+++ b/server/remote/client.go
@@ -39,10 +39,10 @@ type Events interface {
 
 type Subscriptions interface {
 	CreateMySubscription(notificationURL, remoteUserID string) (*Subscription, error)
-	DeleteSubscription(subscriptionID string) error
+	DeleteSubscription(sub *Subscription) error
 	GetNotificationData(*Notification) (*Notification, error)
 	ListSubscriptions() ([]*Subscription, error)
-	RenewSubscription(notificationURL, remoteUserID, subscriptionID string) (*Subscription, error)
+	RenewSubscription(notificationURL, remoteUserID string, sub *Subscription) (*Subscription, error)
 }
 
 type Utils interface {

--- a/server/remote/mock_remote/mock_client.go
+++ b/server/remote/mock_remote/mock_client.go
@@ -154,7 +154,7 @@ func (mr *MockClientMockRecorder) DeleteCalendar(arg0, arg1 interface{}) *gomock
 }
 
 // DeleteSubscription mocks base method.
-func (m *MockClient) DeleteSubscription(arg0 string) error {
+func (m *MockClient) DeleteSubscription(arg0 *remote.Subscription) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteSubscription", arg0)
 	ret0, _ := ret[0].(error)
@@ -333,7 +333,7 @@ func (mr *MockClientMockRecorder) ListSubscriptions() *gomock.Call {
 }
 
 // RenewSubscription mocks base method.
-func (m *MockClient) RenewSubscription(arg0, arg1, arg2 string) (*remote.Subscription, error) {
+func (m *MockClient) RenewSubscription(arg0, arg1 string, arg2 *remote.Subscription) (*remote.Subscription, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RenewSubscription", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*remote.Subscription)

--- a/server/remote/subscription.go
+++ b/server/remote/subscription.go
@@ -5,6 +5,7 @@ package remote
 
 type Subscription struct {
 	ID                 string `json:"id"`
+	ResourceID         string `json:"resourceId,omitempty"`
 	Resource           string `json:"resource,omitempty"`
 	ApplicationID      string `json:"applicationId,omitempty"`
 	ChangeType         string `json:"changeType,omitempty"`


### PR DESCRIPTION
#### Summary
- Fixes gcal unsubscriptions not working properly because it required two identifiers instead of only one
