### PR TITLE
[GCAL] Summary command fixes

### DIFF
--- a/server/command/command.go
+++ b/server/command/command.go
@@ -36,6 +36,19 @@ type handleFunc func(parameters ...string) (string, bool, error)
 var cmds = []*model.AutocompleteData{
 	model.NewAutocompleteData("connect", "", fmt.Sprintf("Connect to your %s account", config.Provider.DisplayName)),
 	model.NewAutocompleteData("disconnect", "", fmt.Sprintf("Disconnect from your %s account", config.Provider.DisplayName)),
+	{
+		Trigger:  "summary",
+		HelpText: "View your events for today, or edit the settings for your daily summary.",
+		SubCommands: []*model.AutocompleteData{
+			model.NewAutocompleteData("view", "", "View your daily summary."),
+			model.NewAutocompleteData("today", "", "Display today's events."),
+			model.NewAutocompleteData("tomorrow", "", "Display tomorrow's events."),
+			model.NewAutocompleteData("settings", "", "View your settings for the daily summary."),
+			model.NewAutocompleteData("time", "", "Set the time you would like to receive your daily summary."),
+			model.NewAutocompleteData("enable", "", "Enable your daily summary."),
+			model.NewAutocompleteData("disable", "", "Disable your daily summary."),
+		},
+	},
 	model.NewAutocompleteData("summary", "", "View your events for today, or edit the settings for your daily summary."),
 	model.NewAutocompleteData("viewcal", "", "View your events for the upcoming week."),
 	model.NewAutocompleteData("today", "", "Display today's events."),

--- a/server/command/daily_summary.go
+++ b/server/command/daily_summary.go
@@ -8,19 +8,22 @@ import (
 	"github.com/mattermost/mattermost-plugin-mscalendar/server/store"
 )
 
-var (
-	dailySummaryHelp = "### Daily summary commands:\n" +
+func getDailySummaryHelp() string {
+	return "### Daily summary commands:\n" +
 		fmt.Sprintf("`/%s summary view` - View your daily summary\n", config.Provider.CommandTrigger) +
 		fmt.Sprintf("`/%s summary settings` - View your settings for the daily summary\n", config.Provider.CommandTrigger) +
 		fmt.Sprintf("`/%s summary time 8:00AM` - Set the time you would like to receive your daily summary\n", config.Provider.CommandTrigger) +
 		fmt.Sprintf("`/%s summary enable` - Enable your daily summary\n", config.Provider.CommandTrigger) +
 		fmt.Sprintf("`/%s summary disable` - Disable your daily summary", config.Provider.CommandTrigger)
-	dailySummarySetTimeErrorMessage = fmt.Sprintf("Please enter a time, for example:\n`/%s summary time 8:00AM`", config.Provider.CommandTrigger)
-)
+}
+
+func getDailySummarySetTimeErrorMessage() string {
+	return fmt.Sprintf("Please enter a time, for example:\n`/%s summary time 8:00AM`", config.Provider.CommandTrigger)
+}
 
 func (c *Command) dailySummary(parameters ...string) (string, bool, error) {
 	if len(parameters) == 0 {
-		return dailySummaryHelp, false, nil
+		return getDailySummaryHelp(), false, nil
 	}
 
 	switch parameters[0] {
@@ -38,20 +41,20 @@ func (c *Command) dailySummary(parameters ...string) (string, bool, error) {
 		return postStr, false, nil
 	case "time":
 		if len(parameters) != 2 {
-			return dailySummarySetTimeErrorMessage, false, nil
+			return getDailySummarySetTimeErrorMessage(), false, nil
 		}
 		val := parameters[1]
 
 		dsum, err := c.MSCalendar.SetDailySummaryPostTime(c.user(), val)
 		if err != nil {
-			return err.Error() + "\n" + dailySummarySetTimeErrorMessage, false, nil
+			return err.Error() + "\n" + getDailySummarySetTimeErrorMessage(), false, nil
 		}
 
 		return dailySummaryResponse(dsum), false, nil
 	case "settings":
 		dsum, err := c.MSCalendar.GetDailySummarySettingsForUser(c.user())
 		if err != nil {
-			return err.Error() + "\nYou may need to configure your daily summary using the commands below.\n" + dailySummaryHelp, false, nil
+			return err.Error() + "\nYou may need to configure your daily summary using the commands below.\n" + getDailySummaryHelp(), false, nil
 		}
 
 		return dailySummaryResponse(dsum), false, nil
@@ -69,12 +72,12 @@ func (c *Command) dailySummary(parameters ...string) (string, bool, error) {
 		}
 		return dailySummaryResponse(dsum), false, nil
 	}
-	return "Invalid command. Please try again\n\n" + dailySummaryHelp, false, nil
+	return "Invalid command. Please try again\n\n" + getDailySummaryHelp(), false, nil
 }
 
 func dailySummaryResponse(dsum *store.DailySummaryUserSettings) string {
 	if dsum.PostTime == "" {
-		return "Your daily summary time is not yet configured.\n" + dailySummarySetTimeErrorMessage
+		return "Your daily summary time is not yet configured.\n" + getDailySummarySetTimeErrorMessage()
 	}
 
 	enableStr := ""

--- a/server/mscalendar/daily_summary_test.go
+++ b/server/mscalendar/daily_summary_test.go
@@ -153,9 +153,9 @@ func TestProcessAllDailySummary(t *testing.T) {
 					mockPoster.EXPECT().DM("user2_mm_id", `Times are shown in Pacific Standard Time
 Wednesday February 12, 2020
 
-| Time | Subject | |
-| :-- | :-- | :-- |
-| 9:00AM - 11:00AM | [The subject]() | [Join meeting](https://zoom.us/j/123) |`).Return("postID2", nil).Times(1),
+| Time | Subject |
+| :-- | :-- |
+| 9:00AM - 11:00AM | [The subject]() |`).Return("postID2", nil).Times(1),
 				)
 
 				s.EXPECT().StoreUser(gomock.Any()).Times(2).DoAndReturn(func(u *store.User) error {
@@ -260,9 +260,9 @@ Wednesday February 12, 2020
 					mockPoster.EXPECT().DM("user2_mm_id", `Times are shown in Pacific Standard Time
 Wednesday February 12, 2020
 
-| Time | Subject | |
-| :-- | :-- | :-- |
-| 9:00AM - 11:00AM | [The subject]() |  |`).Return("postID2", nil).Times(1),
+| Time | Subject |
+| :-- | :-- |
+| 9:00AM - 11:00AM | [The subject]() |`).Return("postID2", nil).Times(1),
 				)
 
 				s.EXPECT().StoreUser(gomock.Any()).Times(2).DoAndReturn(func(u *store.User) error {

--- a/server/mscalendar/views/calendar.go
+++ b/server/mscalendar/views/calendar.go
@@ -12,6 +12,13 @@ import (
 	"github.com/mattermost/mattermost-plugin-mscalendar/server/remote"
 )
 
+var subjectReplacer = strings.NewReplacer(
+	"|", `\|`,
+	"[", `\[`,
+	"]", `\]`,
+	">", `\>`,
+)
+
 func RenderCalendarView(events []*remote.Event, timeZone string) (string, error) {
 	if len(events) == 0 {
 		return "You have no upcoming events.", nil
@@ -104,7 +111,7 @@ func renderEvent(event *remote.Event, asRow bool, timeZone string) (string, erro
 
 	subject := EnsureSubject(event.Subject)
 
-	return fmt.Sprintf(format, start, end, CleanSubject(subject), link), nil
+	return fmt.Sprintf(format, start, end, subjectReplacer.Replace(subject), link), nil
 }
 
 func isKnownMeetingURL(location string) bool {
@@ -182,10 +189,6 @@ func EnsureSubject(s string) string {
 	}
 
 	return s
-}
-
-func CleanSubject(s string) string {
-	return strings.ReplaceAll(s, "|", `\|`)
 }
 
 func RenderUpcomingEventAsAttachment(event *remote.Event, timeZone string) (message string, attachment *model.SlackAttachment, err error) {

--- a/server/mscalendar/views/calendar.go
+++ b/server/mscalendar/views/calendar.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/url"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/mattermost/mattermost-server/v6/model"
@@ -84,8 +83,8 @@ func RenderDaySummary(events []*remote.Event, timezone string) (string, []*model
 }
 
 func renderTableHeader() string {
-	return `| Time | Subject | |
-| :-- | :-- | :-- |`
+	return `| Time | Subject |
+| :-- | :-- |`
 }
 
 func renderEvent(event *remote.Event, asRow bool, timeZone string) (string, error) {
@@ -94,7 +93,7 @@ func renderEvent(event *remote.Event, asRow bool, timeZone string) (string, erro
 
 	format := "(%s - %s) [%s](%s)"
 	if asRow {
-		format = "| %s - %s | [%s](%s) | %s |"
+		format = "| %s - %s | [%s](%s) |"
 	}
 
 	link, err := url.QueryUnescape(event.Weblink)
@@ -102,18 +101,9 @@ func renderEvent(event *remote.Event, asRow bool, timeZone string) (string, erro
 		return "", err
 	}
 
-	var other string
-	if event.Location != nil && isKnownMeetingURL(event.Location.DisplayName) {
-		other = "[Join meeting](" + event.Location.DisplayName + ")"
-	}
-
 	subject := EnsureSubject(event.Subject)
 
-	return fmt.Sprintf(format, start, end, subject, link, other), nil
-}
-
-func isKnownMeetingURL(location string) bool {
-	return strings.Contains(location, "zoom.us/j/") || strings.Contains(location, "discord.gg") || strings.Contains(location, "meet.google.com")
+	return fmt.Sprintf(format, start, end, subject, link), nil
 }
 
 func renderEventAsAttachment(event *remote.Event, timezone string) (*model.SlackAttachment, error) {

--- a/server/mscalendar/views/calendar.go
+++ b/server/mscalendar/views/calendar.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/mattermost/mattermost-server/v6/model"
@@ -103,7 +104,7 @@ func renderEvent(event *remote.Event, asRow bool, timeZone string) (string, erro
 
 	subject := EnsureSubject(event.Subject)
 
-	return fmt.Sprintf(format, start, end, subject, link), nil
+	return fmt.Sprintf(format, start, end, CleanSubject(subject), link), nil
 }
 
 func renderEventAsAttachment(event *remote.Event, timezone string) (*model.SlackAttachment, error) {
@@ -176,6 +177,10 @@ func EnsureSubject(s string) string {
 	}
 
 	return s
+}
+
+func CleanSubject(s string) string {
+	return strings.ReplaceAll(s, "|", `\|`)
 }
 
 func RenderUpcomingEventAsAttachment(event *remote.Event, timeZone string) (message string, attachment *model.SlackAttachment, err error) {

--- a/server/mscalendar/views/calendar.go
+++ b/server/mscalendar/views/calendar.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/mattermost/mattermost-server/v6/model"


### PR DESCRIPTION
#### Summary
- Fixes command trigger not being shown with the `/trigger summary` command help.
- Adds autocomplete data to the `/trigger summary` command.
- Removes the "Join meeting" column from table vies.
- Escape subject symbols: `|`, `[`, `]`,`>`

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-53887
- https://mattermost.atlassian.net/browse/MM-53889
- https://mattermost.atlassian.net/browse/MM-53892
- https://mattermost.atlassian.net/browse/MM-53893
