### PR TITLE
[GCAL] Use correct `MANIFEST_FILE` on `bin/manifest` calls.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ server-debug: server-debug-deploy reset
 
 .PHONY: server-debug-deploy
 server-debug-deploy: validate-go-version
-	./build/bin/manifest apply
+	MANIFEST_FILE=$(MANIFEST_FILE) ./build/bin/manifest apply
 	mkdir -p server/dist
 ifeq ($(OS),Darwin)
 	cd server && env GOOS=darwin GOARCH=amd64 $(GOBUILD) -gcflags "all=-N -l" -o dist/plugin-darwin-amd64;

--- a/build/setup.mk
+++ b/build/setup.mk
@@ -18,16 +18,16 @@ ifeq ($(PLUGIN_ID),)
 endif
 
 # Extract the plugin version from the manifest.
-PLUGIN_VERSION ?= $(shell build/bin/manifest version)
+PLUGIN_VERSION ?= $(shell MANIFEST_FILE=$(MANIFEST_FILE) build/bin/manifest version)
 ifeq ($(PLUGIN_VERSION),)
     $(error "Cannot parse version from $(MANIFEST_FILE)")
 endif
 
 # Determine if a server is defined in the manifest.
-HAS_SERVER ?= $(shell build/bin/manifest has_server)
+HAS_SERVER ?= $(shell MANIFEST_FILE=$(MANIFEST_FILE) build/bin/manifest has_server)
 
 # Determine if a webapp is defined in the manifest.
-HAS_WEBAPP ?= $(shell build/bin/manifest has_webapp)
+HAS_WEBAPP ?= $(shell MANIFEST_FILE=$(MANIFEST_FILE) build/bin/manifest has_webapp)
 
 # Determine if a /public folder is in use
 HAS_PUBLIC ?= $(wildcard public/.)


### PR DESCRIPTION
#### Summary

Add the correct `MANIFEST_FILE` environment variable to all `bin/manifest` calls that didn't have it setup.