### PR TITLE
[GCAL] Event notifications behind a feature flag

### DIFF
--- a/providers/gcal.go
+++ b/providers/gcal.go
@@ -23,7 +23,9 @@ func GetGcalProviderConfig() *config.ProviderConfig {
 
 		BotUsername:    ProviderGCal,
 		BotDisplayName: ProviderGCalDisplayName,
-
-		EncryptedStore: true,
+		Features: config.ProviderFeatures{
+			EncryptedStore:     true,
+			EventNotifications: false,
+		},
 	}
 }

--- a/providers/mscalendar.go
+++ b/providers/mscalendar.go
@@ -24,6 +24,9 @@ func GetMSCalendarProviderConfig() *config.ProviderConfig {
 		BotUsername:    ProviderMSCalendar,
 		BotDisplayName: ProviderMSCalendarDisplayName,
 
-		EncryptedStore: false,
+		Features: config.ProviderFeatures{
+			EncryptedStore:     false,
+			EventNotifications: true,
+		},
 	}
 }

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -41,8 +41,6 @@ var cmds = []*model.AutocompleteData{
 	model.NewAutocompleteData("today", "", "Display today's events."),
 	model.NewAutocompleteData("tomorrow", "", "Display tomorrow's events."),
 	model.NewAutocompleteData("settings", "", "Edit your user personal settings."),
-	// model.NewAutocompleteData("subscribe", "", "Enable notifications for event invitations and updates."),
-	// model.NewAutocompleteData("unsubscribe", "", "Disable notifications for event invitations and updates."),
 	model.NewAutocompleteData("info", "", "Read information about this version of the plugin."),
 	model.NewAutocompleteData("help", "", "Read help text for the commands"),
 }
@@ -101,18 +99,19 @@ func (c *Command) Handle() (string, bool, error) {
 		handler = c.requireConnectedUser(c.createEvent)
 	case "deletecal":
 		handler = c.requireConnectedUser(c.deleteCalendar)
-	case "subscribe":
-		handler = c.requireConnectedUser(c.subscribe)
-	case "unsubscribe":
-		handler = c.requireConnectedUser(c.unsubscribe)
 	case "findmeetings":
 		handler = c.requireConnectedUser(c.findMeetings)
 	case "showcals":
 		handler = c.requireConnectedUser(c.showCalendars)
-	case "avail":
-		handler = c.requireConnectedUser(c.requireAdminUser(c.debugAvailability))
 	case "settings":
 		handler = c.requireConnectedUser(c.settings)
+	// Admin only
+	case "avail":
+		handler = c.requireConnectedUser(c.requireAdminUser(c.debugAvailability))
+	case "subscribe":
+		handler = c.requireConnectedUser(c.requireAdminUser(c.subscribe))
+	case "unsubscribe":
+		handler = c.requireConnectedUser(c.requireAdminUser(c.unsubscribe))
 	// Aliases
 	case "today":
 		parameters = []string{"today"}

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -41,8 +41,8 @@ var cmds = []*model.AutocompleteData{
 	model.NewAutocompleteData("today", "", "Display today's events."),
 	model.NewAutocompleteData("tomorrow", "", "Display tomorrow's events."),
 	model.NewAutocompleteData("settings", "", "Edit your user personal settings."),
-	model.NewAutocompleteData("subscribe", "", "Enable notifications for event invitations and updates."),
-	model.NewAutocompleteData("unsubscribe", "", "Disable notifications for event invitations and updates."),
+	// model.NewAutocompleteData("subscribe", "", "Enable notifications for event invitations and updates."),
+	// model.NewAutocompleteData("unsubscribe", "", "Disable notifications for event invitations and updates."),
 	model.NewAutocompleteData("info", "", "Read information about this version of the plugin."),
 	model.NewAutocompleteData("help", "", "Read help text for the commands"),
 }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -18,6 +18,11 @@ type StoredConfig struct {
 	GoogleDomainVerifyKey string
 }
 
+type ProviderFeatures struct {
+	EncryptedStore     bool
+	EventNotifications bool
+}
+
 // ProviderConfig represents the specific configuration that changes when building for different
 // calendar providers.
 type ProviderConfig struct {
@@ -28,7 +33,7 @@ type ProviderConfig struct {
 	TelemetryShortName string
 	BotUsername        string
 	BotDisplayName     string
-	EncryptedStore     bool
+	Features           ProviderFeatures
 }
 
 // Config represents the the metadata handed to all request runners (command,

--- a/server/mscalendar/settings.go
+++ b/server/mscalendar/settings.go
@@ -1,6 +1,7 @@
 package mscalendar
 
 import (
+	"github.com/mattermost/mattermost-plugin-mscalendar/server/config"
 	"github.com/mattermost/mattermost-plugin-mscalendar/server/store"
 	"github.com/mattermost/mattermost-plugin-mscalendar/server/utils/bot"
 	"github.com/mattermost/mattermost-plugin-mscalendar/server/utils/settingspanel"
@@ -22,7 +23,7 @@ func (m *mscalendar) ClearSettingsPosts(userID string) {
 	}
 }
 
-func NewSettingsPanel(bot bot.Bot, panelStore settingspanel.PanelStore, settingStore settingspanel.SettingStore, settingsHandler, pluginURL string, getCal func(userID string) MSCalendar) settingspanel.Panel {
+func NewSettingsPanel(bot bot.Bot, panelStore settingspanel.PanelStore, settingStore settingspanel.SettingStore, settingsHandler, pluginURL string, getCal func(userID string) MSCalendar, providerFeatures config.ProviderFeatures) settingspanel.Panel {
 	settings := []settingspanel.Setting{}
 	settings = append(settings, settingspanel.NewBoolSetting(
 		store.UpdateStatusSettingID,
@@ -52,7 +53,9 @@ func NewSettingsPanel(bot bot.Bot, panelStore settingspanel.PanelStore, settingS
 		"",
 		settingStore,
 	))
-	settings = append(settings, NewNotificationsSetting(getCal))
+	if providerFeatures.EventNotifications {
+		settings = append(settings, NewNotificationsSetting(getCal))
+	}
 	settings = append(settings, NewDailySummarySetting(
 		settingStore,
 		func(userID string) (string, error) { return getCal(userID).GetTimezone(NewUser(userID)) },

--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -200,10 +200,12 @@ func (p *Plugin) OnConfigurationChange() (err error) {
 		welcomeFlow := mscalendar.NewWelcomeFlow(e.bot, e.Dependencies.Welcomer, e.Provider.Features)
 		e.bot.RegisterFlow(welcomeFlow, mscalendarBot)
 
-		if e.notificationProcessor == nil && e.Provider.Features.EventNotifications {
-			e.notificationProcessor = mscalendar.NewNotificationProcessor(e.Env)
-		} else {
-			e.notificationProcessor.Configure(e.Env)
+		if e.Provider.Features.EventNotifications {
+			if e.notificationProcessor == nil {
+				e.notificationProcessor = mscalendar.NewNotificationProcessor(e.Env)
+			} else {
+				e.notificationProcessor.Configure(e.Env)
+			}
 		}
 
 		e.httpHandler = httputils.NewHandler()

--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -111,7 +111,7 @@ func (p *Plugin) OnActivate() error {
 			),
 		)
 		e.bot = e.bot.WithConfig(stored.Config)
-		e.Dependencies.Store = store.NewPluginStore(p.API, e.bot, e.Dependencies.Tracker, e.Provider.EncryptedStore, []byte(e.EncryptionKey))
+		e.Dependencies.Store = store.NewPluginStore(p.API, e.bot, e.Dependencies.Tracker, e.Provider.Features.EncryptedStore, []byte(e.EncryptionKey))
 	})
 
 	return nil
@@ -184,7 +184,7 @@ func (p *Plugin) OnConfigurationChange() (err error) {
 
 		e.Dependencies.Poster = e.bot
 		e.Dependencies.Welcomer = mscalendarBot
-		e.Dependencies.Store = store.NewPluginStore(p.API, e.bot, e.Dependencies.Tracker, e.Provider.EncryptedStore, []byte(e.EncryptionKey))
+		e.Dependencies.Store = store.NewPluginStore(p.API, e.bot, e.Dependencies.Tracker, e.Provider.Features.EncryptedStore, []byte(e.EncryptionKey))
 		e.Dependencies.SettingsPanel = mscalendar.NewSettingsPanel(
 			e.bot,
 			e.Dependencies.Store,
@@ -194,12 +194,13 @@ func (p *Plugin) OnConfigurationChange() (err error) {
 			func(userID string) mscalendar.MSCalendar {
 				return mscalendar.New(e.Env, userID)
 			},
+			e.Provider.Features,
 		)
 
-		welcomeFlow := mscalendar.NewWelcomeFlow(e.bot, e.Dependencies.Welcomer)
+		welcomeFlow := mscalendar.NewWelcomeFlow(e.bot, e.Dependencies.Welcomer, e.Provider.Features)
 		e.bot.RegisterFlow(welcomeFlow, mscalendarBot)
 
-		if e.notificationProcessor == nil {
+		if e.notificationProcessor == nil && e.Provider.Features.EventNotifications {
 			e.notificationProcessor = mscalendar.NewNotificationProcessor(e.Env)
 		} else {
 			e.notificationProcessor.Configure(e.Env)


### PR DESCRIPTION
#### Summary

Only enable event notifications if the provider allows it, along with any relevant settings and wizard option

The subscribe/unsubscribe commands are removed from autocompletion and only admin can use them from now on.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-53918
