### PR TITLE
typo: user already connected message

### DIFF
--- a/server/mscalendar/oauth2.go
+++ b/server/mscalendar/oauth2.go
@@ -81,8 +81,8 @@ func (app *oauth2App) CompleteOAuth2(authedUserID, code, state string) error {
 	if err == nil {
 		user, userErr := app.PluginAPI.GetMattermostUser(uid)
 		if userErr == nil {
-			app.Poster.DM(authedUserID, RemoteUserAlreadyConnected, config.Provider.DisplayName, me.Mail, config.Provider.CommandTrigger, user.Username)
-			return fmt.Errorf(RemoteUserAlreadyConnected, config.Provider.DisplayName, me.Mail, config.Provider.CommandTrigger, user.Username)
+			app.Poster.DM(authedUserID, RemoteUserAlreadyConnected, config.Provider.DisplayName, me.Mail, user.Username, config.Provider.CommandTrigger)
+			return fmt.Errorf(RemoteUserAlreadyConnected, config.Provider.DisplayName, me.Mail, user.Username, config.Provider.CommandTrigger)
 		}
 
 		// Couldn't fetch connected MM account. Reject connect attempt.

--- a/server/mscalendar/oauth2_test.go
+++ b/server/mscalendar/oauth2_test.go
@@ -215,8 +215,8 @@ func TestCompleteOAuth2Errors(t *testing.T) {
 					gomock.Eq(RemoteUserAlreadyConnected),
 					gomock.Eq(config.Provider.DisplayName),
 					gomock.Eq("mail-value"),
-					gomock.Eq(config.Provider.CommandTrigger),
 					gomock.Eq("sample-username"),
+					gomock.Eq(config.Provider.CommandTrigger),
 				).Return("post_id", nil).Times(1)
 			},
 		},


### PR DESCRIPTION
#### Summary

Fixes a small typo I found where the username and the command trigger were in wrong positions.

#### Ticket Link

