### PR TITLE
[GCAL/MSCAL] Exclude rejected events from agenda commands

### DIFF
--- a/server/mscalendar/calendar.go
+++ b/server/mscalendar/calendar.go
@@ -48,7 +48,7 @@ func (m *mscalendar) getTodayCalendarEvents(user *User, now time.Time, timezone 
 
 func (m *mscalendar) excludeDeclinedEvents(events []*remote.Event) (result []*remote.Event) {
 	for ix, evt := range events {
-		if evt.ResponseStatus.Response != remote.EventResponseStatusDeclined {
+		if evt.ResponseStatus == nil || evt.ResponseStatus.Response != remote.EventResponseStatusDeclined {
 			result = append(result, events[ix])
 		}
 	}

--- a/server/mscalendar/daily_summary.go
+++ b/server/mscalendar/daily_summary.go
@@ -228,7 +228,9 @@ func (m *mscalendar) GetDaySummaryForUser(day time.Time, user *User) (string, er
 		return "Failed to get calendar events", err
 	}
 
-	messageString, err := views.RenderCalendarView(calendarData, tz)
+	events := m.excludeDeclinedEvents(calendarData)
+
+	messageString, err := views.RenderCalendarView(events, tz)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to render daily summary")
 	}


### PR DESCRIPTION
#### Summary
In order to be consistent with reminders, exclude events that have been rejected from the agenda commands.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-54172
