### PR TITLE
[GCAL/MSCAL] Create event modal only for connected accounts

### DIFF
--- a/server/api/api.go
+++ b/server/api/api.go
@@ -4,6 +4,8 @@
 package api
 
 import (
+	"net/http"
+
 	"github.com/mattermost/mattermost-plugin-mscalendar/server/config"
 	"github.com/mattermost/mattermost-plugin-mscalendar/server/mscalendar"
 	"github.com/mattermost/mattermost-plugin-mscalendar/server/utils/httputils"
@@ -40,4 +42,10 @@ func Init(h *httputils.Handler, env mscalendar.Env, notificationProcessor mscale
 	apiRoutes := h.Router.PathPrefix(config.InternalAPIPath).Subrouter()
 	eventsRouter := apiRoutes.PathPrefix(config.PathEvents).Subrouter()
 	eventsRouter.HandleFunc(config.PathCreate, api.createEvent).Methods("POST")
+	apiRoutes.HandleFunc(config.PathConnectedUser, api.connectedUserHandler)
+
+	// Returns provider information for the plugin to use
+	apiRoutes.HandleFunc(config.PathProvider, func(w http.ResponseWriter, r *http.Request) {
+		httputils.WriteJSONResponse(w, config.Provider, 200)
+	})
 }

--- a/server/api/connected_user.go
+++ b/server/api/connected_user.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/mattermost/mattermost-plugin-mscalendar/server/store"
+	"github.com/mattermost/mattermost-plugin-mscalendar/server/utils/httputils"
+)
+
+func (api *api) connectedUserHandler(w http.ResponseWriter, r *http.Request) {
+	mattermostUserID := r.Header.Get("Mattermost-User-Id")
+	if mattermostUserID == "" {
+		httputils.WriteUnauthorizedError(w, fmt.Errorf("unauthorized"))
+		return
+	}
+
+	_, errStore := api.Store.LoadUser(mattermostUserID)
+	if errStore != nil && !errors.Is(errStore, store.ErrNotFound) {
+		httputils.WriteInternalServerError(w, errStore)
+		return
+	}
+	if errors.Is(errStore, store.ErrNotFound) {
+		httputils.WriteUnauthorizedError(w, fmt.Errorf("unauthorized"))
+		return
+	}
+
+	w.Write([]byte(`{"is_connected": true}`))
+}

--- a/server/config/const.go
+++ b/server/config/const.go
@@ -27,9 +27,11 @@ const (
 	PathUsers        = "/users"
 	PathChannels     = "/channels"
 
-	InternalAPIPath = "/api/v1"
-	PathEvents      = "/events"
-	PathCreate      = "/create"
+	InternalAPIPath   = "/api/v1"
+	PathEvents        = "/events"
+	PathCreate        = "/create"
+	PathProvider      = "/provider"
+	PathConnectedUser = "/me"
 
 	FullPathEventNotification = PathNotification + PathEvent
 	FullPathOAuth2Redirect    = PathOAuth2 + PathComplete

--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -1,12 +1,15 @@
 import Client4 from 'mattermost-redux/client/client4';
+import {PostTypes} from 'mattermost-redux/action_types';
 import {GlobalState} from 'mattermost-redux/types/store';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {haveIChannelPermission} from 'mattermost-redux/selectors/entities/roles';
 import Permissions from 'mattermost-redux/constants/permissions';
 import {Channel} from '@mattermost/types/lib/channels';
 
+import {getCurrentChannelId} from 'mattermost-redux/selectors/entities/common';
+
 import ActionTypes from './action_types';
-import {doFetchWithResponse} from './client';
+import {doFetch, doFetchWithResponse} from './client';
 import {PluginId} from './plugin_id';
 import {CreateEventPayload} from './types/calendar_api_types';
 
@@ -107,3 +110,48 @@ export const createCalendarEvent = (payload: CreateEventPayload) => async (dispa
             return {error};
         });
 };
+
+export function getConnected() {
+    return async (dispatch, getState) => {
+        let data;
+        const baseUrl = getPluginServerRoute(getState());
+        try {
+            data = await doFetch(`${baseUrl}/api/v1/me`, {
+                method: 'get',
+            });
+        } catch (error) {
+            return {error};
+        }
+
+        dispatch({
+            type: ActionTypes.RECEIVED_CONNECTED,
+            data,
+        });
+
+        return {data};
+    };
+}
+
+export function sendEphemeralPost(message: string, channelId?: string) {
+    return (dispatch, getState) => {
+        const timestamp = Date.now();
+        const post = {
+            id: 'jiraPlugin' + Date.now(),
+            user_id: getState().entities.users.currentUserId,
+            channel_id: channelId || getCurrentChannelId(getState()),
+            message,
+            type: 'system_ephemeral',
+            create_at: timestamp,
+            update_at: timestamp,
+            root_id: '',
+            parent_id: '',
+            props: {},
+        };
+
+        dispatch({
+            type: PostTypes.RECEIVED_NEW_POST,
+            data: post,
+            channelId,
+        });
+    };
+}

--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -136,7 +136,7 @@ export function sendEphemeralPost(message: string, channelId?: string) {
     return (dispatch, getState) => {
         const timestamp = Date.now();
         const post = {
-            id: 'jiraPlugin' + Date.now(),
+            id: 'gcalplugin_' + Date.now(),
             user_id: getState().entities.users.currentUserId,
             channel_id: channelId || getCurrentChannelId(getState()),
             message,

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -30,7 +30,12 @@ export default class Plugin {
 
         registry.registerChannelHeaderMenuAction(
             <span><i className='icon fa fa-calendar-plus-o'/>{'Create calendar event'}</span>,
-            (channelID) => store.dispatch(openCreateEventModal(channelID)),
+            async (channelID) => {
+                if (await hooks.CheckUserIsConnected()) {
+                    store.dispatch(openCreateEventModal(channelID));
+                    return
+                }
+            }
         );
 
         // reminder to set up site url for any API calls

--- a/webapp/src/plugin_hooks.ts
+++ b/webapp/src/plugin_hooks.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {openCreateEventModal} from './actions';
+import {getConnected, openCreateEventModal, sendEphemeralPost} from './actions';
 import {isUserConnected} from './selectors';
 
 // import {openCreateModalWithoutPost, openChannelSettings, sendEphemeralPost, openDisconnectModal, handleConnectFlow, getConnected} from '../actions';
@@ -52,12 +52,10 @@ export default class Hooks {
     };
 
     checkUserIsConnected = async (): Promise<boolean> => {
-        return true;
-
         if (!isUserConnected(this.store.getState())) {
             await this.store.dispatch(getConnected());
             if (!isUserConnected(this.store.getState())) {
-                this.store.dispatch(sendEphemeralPost('Your Mattermost account is not connected to Jira. Please use `/jira connect` to connect your account, then try again.'));
+                this.store.dispatch(sendEphemeralPost('Your Mattermost account is not connected.'));
                 return false;
             }
         }

--- a/webapp/src/plugin_hooks.ts
+++ b/webapp/src/plugin_hooks.ts
@@ -43,7 +43,7 @@ export default class Hooks {
     };
 
     handleCreateEventSlashCommand = async (message: string, contextArgs: ContextArgs) => {
-        if (!(await this.checkUserIsConnected())) {
+        if (!(await this.CheckUserIsConnected())) {
             return Promise.resolve({});
         }
 
@@ -51,7 +51,7 @@ export default class Hooks {
         return Promise.resolve({});
     };
 
-    checkUserIsConnected = async (): Promise<boolean> => {
+    CheckUserIsConnected = async (): Promise<boolean> => {
         if (!isUserConnected(this.store.getState())) {
             await this.store.dispatch(getConnected());
             if (!isUserConnected(this.store.getState())) {


### PR DESCRIPTION
#### Summary

Prevents non-connected users from opening the create event modal, both from the slash command (soon to be removed) and the channel header menu.

@mickmister how can I properly retrieve data from the backend and store it in the frontend for its use around? I exposed the provider data (to customize the `sendEphemeralMessage` call) but I'm not sure if creating a variable and populating it with the data I get from the backend is appropriate.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-54114