### PR TITLE
[GCAL/MSCAL] Make selected setting use primary button style to show it as active and remove "Current value" line

### DIFF
--- a/server/mscalendar/settings_daily_summary.go
+++ b/server/mscalendar/settings_daily_summary.go
@@ -118,7 +118,6 @@ func (s *dailySummarySetting) GetSlackAttachments(userID, settingHandler string,
 	currentAPM := "AM"
 	fullTime := "8:00AM"
 	currentEnable := false
-	currentTextValue := "Not set."
 
 	if dsum != nil {
 		fullTime = dsum.PostTime
@@ -127,11 +126,6 @@ func (s *dailySummarySetting) GetSlackAttachments(userID, settingHandler string,
 		currentH = splitted[0]
 		currentM = splitted[1][:2]
 		currentAPM = splitted[1][2:]
-		enableText := "Disabled"
-		if currentEnable {
-			enableText = "Enabled"
-		}
-		currentTextValue = fmt.Sprintf("%s (%s) (%s)", dsum.PostTime, dsum.Timezone, enableText)
 	}
 
 	timezone, err := s.getTimezone(userID)
@@ -139,8 +133,6 @@ func (s *dailySummarySetting) GetSlackAttachments(userID, settingHandler string,
 		return nil, fmt.Errorf("could not load the timezone. err=%v", err)
 	}
 	fullTime = fullTime + " " + timezone
-
-	currentValueMessage = fmt.Sprintf("Current value: %s", currentTextValue)
 
 	actionOptionsH := model.PostAction{
 		Name: "H:",
@@ -181,7 +173,9 @@ func (s *dailySummarySetting) GetSlackAttachments(userID, settingHandler string,
 		DefaultOption: fullTime,
 	}
 
-	actions = []*model.PostAction{&actionOptionsH, &actionOptionsM, &actionOptionsAPM}
+	if currentEnable {
+		actions = []*model.PostAction{&actionOptionsH, &actionOptionsM, &actionOptionsAPM}
+	}
 
 	buttonText := "Enable"
 	enable := "true"
@@ -202,12 +196,11 @@ func (s *dailySummarySetting) GetSlackAttachments(userID, settingHandler string,
 
 	actions = append(actions, &actionToggle)
 
-	text := fmt.Sprintf("%s\n%s", s.description, currentValueMessage)
 	sa := model.SlackAttachment{
 		Title:    title,
-		Text:     text,
+		Text:     s.description,
 		Actions:  actions,
-		Fallback: fmt.Sprintf("%s: %s", title, text),
+		Fallback: fmt.Sprintf("%s: %s", title, s.description),
 	}
 	return &sa, nil
 }

--- a/server/utils/settingspanel/bool_setting.go
+++ b/server/utils/settingspanel/bool_setting.go
@@ -73,9 +73,15 @@ func (s *boolSetting) GetDependency() string {
 	return s.dependsOn
 }
 
+func (s *boolSetting) getActionStyle(actionValue, currentValue string) string {
+	if actionValue == currentValue {
+		return "primary"
+	}
+	return "default"
+}
+
 func (s *boolSetting) GetSlackAttachments(userID, settingHandler string, disabled bool) (*model.SlackAttachment, error) {
 	title := fmt.Sprintf("Setting: %s", s.title)
-	currentValueMessage := "Disabled"
 
 	actions := []*model.PostAction{}
 	if !disabled {
@@ -84,14 +90,9 @@ func (s *boolSetting) GetSlackAttachments(userID, settingHandler string, disable
 			return nil, err
 		}
 
-		currentTextValue := "No"
-		if currentValue == "true" {
-			currentTextValue = "Yes"
-		}
-		currentValueMessage = fmt.Sprintf("Current value: %s", currentTextValue)
-
 		actionTrue := model.PostAction{
-			Name: "Yes",
+			Name:  "Yes",
+			Style: s.getActionStyle("true", currentValue.(string)),
 			Integration: &model.PostActionIntegration{
 				URL: settingHandler,
 				Context: map[string]interface{}{
@@ -102,7 +103,8 @@ func (s *boolSetting) GetSlackAttachments(userID, settingHandler string, disable
 		}
 
 		actionFalse := model.PostAction{
-			Name: "No",
+			Name:  "No",
+			Style: s.getActionStyle("false", currentValue.(string)),
 			Integration: &model.PostActionIntegration{
 				URL: settingHandler,
 				Context: map[string]interface{}{
@@ -114,12 +116,11 @@ func (s *boolSetting) GetSlackAttachments(userID, settingHandler string, disable
 		actions = []*model.PostAction{&actionTrue, &actionFalse}
 	}
 
-	text := fmt.Sprintf("%s\n%s", s.description, currentValueMessage)
 	sa := model.SlackAttachment{
 		Title:    title,
-		Text:     text,
+		Text:     s.description,
 		Actions:  actions,
-		Fallback: fmt.Sprintf("%s: %s", title, text),
+		Fallback: fmt.Sprintf("%s: %s", title, s.description),
 	}
 
 	return &sa, nil

--- a/server/utils/settingspanel/option_setting.go
+++ b/server/utils/settingspanel/option_setting.go
@@ -75,7 +75,7 @@ func (s *optionSetting) GetSlackAttachments(userID, settingHandler string, disab
 		if err != nil {
 			return nil, err
 		}
-		currentValueMessage = fmt.Sprintf("Current value: %s", currentTextValue)
+		currentValueMessage = fmt.Sprintf("**Current value:** %s", currentTextValue)
 
 		actionOptions := model.PostAction{
 			Name: "Select an option:",


### PR DESCRIPTION
#### Summary

- Uses the `primary` style in setting buttons for the enabled setting
- Removes the `Current value` line for bool and daily summary settings.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53891

