### PR TITLE
[GCAL/MSCAL] Show link to connect on error message "user is not connected"

### DIFF
--- a/server/command/command.go
+++ b/server/command/command.go
@@ -27,8 +27,13 @@ type Command struct {
 	ChannelID  string
 }
 
-func getNotConnectedText() string {
-	return fmt.Sprintf("It looks like your Mattermost account is not connected to a %s account. Please connect your account using `/%s connect`.", config.Provider.DisplayName, config.Provider.CommandTrigger)
+func getNotConnectedText(pluginURL string) string {
+	return fmt.Sprintf(
+		"It looks like your Mattermost account is not connected to a %s account. [Click here to connect your account](%s/oauth2/connect) or use `/%s connect`.",
+		config.Provider.DisplayName,
+		pluginURL,
+		config.Provider.CommandTrigger,
+	)
 }
 
 type handleFunc func(parameters ...string) (string, bool, error)
@@ -175,7 +180,7 @@ func (c *Command) requireConnectedUser(handle handleFunc) handleFunc {
 		}
 
 		if !connected {
-			return getNotConnectedText(), false, nil
+			return getNotConnectedText(c.Config.PluginURL), false, nil
 		}
 		return handle(parameters...)
 	}

--- a/server/command/disconnect_test.go
+++ b/server/command/disconnect_test.go
@@ -32,7 +32,7 @@ func TestDisconnect(t *testing.T) {
 				mscal := m.(*mock_mscalendar.MockMSCalendar)
 				mscal.EXPECT().GetRemoteUser("user_id").Return(&remote.User{}, store.ErrNotFound).Times(1)
 			},
-			expectedOutput: getNotConnectedText(),
+			expectedOutput: getNotConnectedText("http://localhost"),
 			expectedError:  "",
 		},
 		{


### PR DESCRIPTION
#### Summary

Adds a link to connect the account directly in the message shown to users when they tried to use a command that requires a connected account.

![Screenshot 2023-08-22 at 17 46 52](https://github.com/mattermost/mattermost-plugin-mscalendar/assets/812088/fedae35f-8080-47c3-8b3e-239a1d04585b)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53883
