### PR TITLE
[GCAL/MSCAL] Use `npm run bulid` when making plugin bundles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ endif
 .PHONY: webapp
 webapp: webapp/.npminstall
 ifneq ($(HAS_WEBAPP),)
-	cd webapp && $(NPM) run debug;
+	cd webapp && $(NPM) run build;
 endif
 
 ## Builds the webapp in debug mode, if it exists.


### PR DESCRIPTION
#### Summary

Changed the build command for the webapp to `build` so it can be deployed in production enviornments.