### PR TITLE
fix: only add user to process availability if no errors are found

### DIFF
--- a/calendar/engine/availability.go
+++ b/calendar/engine/availability.go
@@ -114,8 +114,6 @@ func (m *mscalendar) retrieveUsersToSync(userIndex store.UserIndex, syncJobSumma
 			continue
 		}
 
-		users = append(users, user)
-
 		if fetchIndividually {
 			engine, err := m.FilterCopy(withActingUser(user.MattermostUserID))
 			if err != nil {
@@ -133,9 +131,13 @@ func (m *mscalendar) retrieveUsersToSync(userIndex store.UserIndex, syncJobSumma
 				}).Errorf("error getting calendar events")
 				continue
 			}
+
 			calendarViews = append(calendarViews, calendarEvents)
 		}
+
+		users = append(users, user)
 	}
+
 	if len(users) == 0 {
 		return users, calendarViews, errNoUsersNeedToBeSynced
 	}


### PR DESCRIPTION
#### Summary

Moved the code that adds users to process at the end of the process loop, since if any error is found the user will be added anyway but we won't have the information to process it.

