### PR TITLE
Replaced legacy GitBook URLs with PL link

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
     "id": "com.mattermost.mscalendar",
     "name": "Microsoft Calendar",
     "description": "Microsoft Calendar Integration",
-    "homepage_url": "https://mattermost.gitbook.io/plugin-mscalendar",
+    "homepage_url": "https://mattermost.com/pl/mattermost-plugin-mscalendar",
     "support_url": "https://github.com/mattermost/mattermost-plugin-mscalendar/issues",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-mscalendar/releases/tag/v1.2.1",
     "icon_path": "assets/profile.svg",


### PR DESCRIPTION
Replaced legacy/broken GitBook link with permalink [via Marketing](https://docs.google.com/spreadsheets/d/1O601H_A0IM8pR3FOfue29_C8flGV7xK3ts-tJUVDHHg/edit#gid=0).

Addresses: https://mattermost.atlassian.net/browse/MM-55436