### PR TITLE
fix: provide fallback attachment text to fix notifications

### DIFF
--- a/calendar/engine/views/calendar.go
+++ b/calendar/engine/views/calendar.go
@@ -176,6 +176,7 @@ func RenderEventAsAttachment(event *remote.Event, timezone string, options ...Op
 		Text:      fmt.Sprintf("%s - %s", event.Start.In(timezone).Time().Format(time.Kitchen), event.End.In(timezone).Time().Format(time.Kitchen)),
 		Fields:    fields,
 		Actions:   actions,
+		Fallback:  fmt.Sprintf("(%s - %s)\n%s", event.Start.In(timezone).Time().Format(time.Kitchen), event.End.In(timezone).Time().Format(time.Kitchen), event.Subject),
 	}
 
 	for _, opt := range options {


### PR DESCRIPTION
#### Summary
This pull request adds a fallback text to event attachment so Mattermost notifications for event reminders are useful.

![IMG_7989](https://github.com/mattermost/mattermost-plugin-mscalendar/assets/812088/085f3a7e-4ace-40bf-a4c5-c12a9f1aeee6)

Fixes #338 