### PR TITLE
[MM-595] Fix issue of plugin crashing on empty site url

### DIFF
--- a/calendar/plugin/plugin.go
+++ b/calendar/plugin/plugin.go
@@ -71,6 +71,11 @@ func (p *Plugin) OnActivate() error {
 		return errors.WithMessage(err, "failed to load plugin configuration")
 	}
 
+	mattermostSiteURL := pluginAPIClient.Configuration.GetConfig().ServiceSettings.SiteURL
+	if mattermostSiteURL == nil {
+		return errors.New("please configure the Mattermost server's SiteURL, then restart the plugin.")
+	}
+
 	if errConfig := p.env.Remote.CheckConfiguration(stored); errConfig != nil {
 		return errors.Wrap(errConfig, "failed to configure")
 	}

--- a/calendar/plugin/plugin.go
+++ b/calendar/plugin/plugin.go
@@ -73,7 +73,7 @@ func (p *Plugin) OnActivate() error {
 
 	mattermostSiteURL := pluginAPIClient.Configuration.GetConfig().ServiceSettings.SiteURL
 	if mattermostSiteURL == nil {
-		return errors.New("please configure the Mattermost server's SiteURL, then restart the plugin.")
+		return errors.New("please configure the Mattermost server's SiteURL, then restart the plugin")
 	}
 
 	if errConfig := p.env.Remote.CheckConfiguration(stored); errConfig != nil {


### PR DESCRIPTION
#### Summary
- Fixed the issue of the plugin crashing on an empty site URL
- This will also fix the Google Calendar plugin crashing as seen in https://github.com/mattermost/mattermost-plugin-google-calendar/issues/72 after updating it with the new package
