### PR TITLE
fix: avoid using output from failing function

### DIFF
--- a/calendar/engine/daily_summary.go
+++ b/calendar/engine/daily_summary.go
@@ -115,7 +115,7 @@ func (m *mscalendar) ProcessAllDailySummary(now time.Time) error {
 	for _, user := range userIndex {
 		storeUser, storeErr := m.Store.LoadUser(user.MattermostUserID)
 		if storeErr != nil {
-			m.Logger.Warnf("Error loading user %s for daily summary. err=%v", storeUser.MattermostUserID, storeErr)
+			m.Logger.Warnf("Error loading user %s for daily summary. err=%v", user.MattermostUserID, storeErr)
 			continue
 		}
 		byRemoteID[storeUser.Remote.ID] = storeUser


### PR DESCRIPTION
#### Summary
This pull request fixes a crash that was caused when processing the daily summary for an user that couldn't be retrieved. Since we use the output from the `LoadUser` call in the `Warnf` call, plugin was crashing.