### PR TITLE
Replace hard coded HTTP verb strings with net/http constants

### DIFF
--- a/calendar/api/api.go
+++ b/calendar/api/api.go
@@ -24,24 +24,24 @@ func Init(h *httputils.Handler, env engine.Env, notificationProcessor engine.Not
 	}
 
 	apiRouter := h.Router.PathPrefix(config.PathAPI).Subrouter()
-	apiRouter.HandleFunc("/authorized", api.getAuthorized).Methods("GET")
+	apiRouter.HandleFunc("/authorized", api.getAuthorized).Methods(http.MethodGet)
 
 	notificationRouter := h.Router.PathPrefix(config.PathNotification).Subrouter()
-	notificationRouter.HandleFunc(config.PathEvent, api.notification).Methods("POST")
+	notificationRouter.HandleFunc(config.PathEvent, api.notification).Methods(http.MethodPost)
 
 	postActionRouter := h.Router.PathPrefix(config.PathPostAction).Subrouter()
-	postActionRouter.HandleFunc(config.PathAccept, api.postActionAccept).Methods("POST")
-	postActionRouter.HandleFunc(config.PathDecline, api.postActionDecline).Methods("POST")
-	postActionRouter.HandleFunc(config.PathTentative, api.postActionTentative).Methods("POST")
-	postActionRouter.HandleFunc(config.PathRespond, api.postActionRespond).Methods("POST")
-	postActionRouter.HandleFunc(config.PathConfirmStatusChange, api.postActionConfirmStatusChange).Methods("POST")
+	postActionRouter.HandleFunc(config.PathAccept, api.postActionAccept).Methods(http.MethodPost)
+	postActionRouter.HandleFunc(config.PathDecline, api.postActionDecline).Methods(http.MethodPost)
+	postActionRouter.HandleFunc(config.PathTentative, api.postActionTentative).Methods(http.MethodPost)
+	postActionRouter.HandleFunc(config.PathRespond, api.postActionRespond).Methods(http.MethodPost)
+	postActionRouter.HandleFunc(config.PathConfirmStatusChange, api.postActionConfirmStatusChange).Methods(http.MethodPost)
 
 	dialogRouter := h.Router.PathPrefix(config.PathAutocomplete).Subrouter()
 	dialogRouter.HandleFunc(config.PathUsers, api.autocompleteConnectedUsers)
 
 	apiRoutes := h.Router.PathPrefix(config.InternalAPIPath).Subrouter()
 	eventsRouter := apiRoutes.PathPrefix(config.PathEvents).Subrouter()
-	eventsRouter.HandleFunc(config.PathCreate, api.createEvent).Methods("POST")
+	eventsRouter.HandleFunc(config.PathCreate, api.createEvent).Methods(http.MethodPost)
 	apiRoutes.HandleFunc(config.PathConnectedUser, api.connectedUserHandler)
 
 	// Returns provider information for the plugin to use


### PR DESCRIPTION
#### Summary
- Replace hard-coded HTTP verb strings with constants from `net/http`

#### Ticket Link
N/A
