### PR TITLE
Fix typo, remove unnecessary params variable

### DIFF
--- a/calendar/command/command.go
+++ b/calendar/command/command.go
@@ -159,9 +159,9 @@ func (c *Command) isValid() (subcommand string, parameters []string, err error) 
 		return "", nil, errors.New("invalid arguments to command.Handler")
 	}
 	split := strings.Fields(c.Args.Command)
-	command := split[0]
-	if command != "/"+config.Provider.CommandTrigger {
-		return "", nil, fmt.Errorf("%q is not a supported command. Please contact your system administrator", command)
+	cmd := split[0]
+	if cmd != "/"+config.Provider.CommandTrigger {
+		return "", nil, fmt.Errorf("%q is not a supported command. Please contact your system administrator", cmd)
 	}
 
 	parameters = []string{}

--- a/calendar/engine/oauth2.go
+++ b/calendar/engine/oauth2.go
@@ -21,7 +21,7 @@ const BotWelcomeMessage = "Bot user connected to account %s."
 
 const (
 	RemoteUserAlreadyConnected         = "%s account `%s` is already mapped to Mattermost account `%s`. Please run `/%s disconnect`, while logged in as the Mattermost account"
-	RemoteUserAlreadyConnectedDisabled = "%s account `%s` is already mapped to a Mattermost account, but the account is deactived. Please enable it and run `/%s disconnect`,  while logged in as the other Mattermost account, and try again"
+	RemoteUserAlreadyConnectedDisabled = "%s account `%s` is already mapped to a Mattermost account, but the account is deactivated. Please enable it and run `/%s disconnect`,  while logged in as the other Mattermost account, and try again"
 	RemoteUserAlreadyConnectedNotFound = "%s account `%s` is already mapped to a Mattermost account, but the Mattermost user could not be found"
 )
 

--- a/calendar/engine/views/calendar.go
+++ b/calendar/engine/views/calendar.go
@@ -155,7 +155,7 @@ func RenderEventAsAttachment(event *remote.Event, timezone string, options ...Op
 	}
 
 	if event.Conference != nil {
-		// Use conference URL as title link if theres conference data present
+		// Use conference URL as title link if there's conference data present
 		titleLink = event.Conference.URL
 
 		title := "Meeting URL"

--- a/calendar/remote/notification.go
+++ b/calendar/remote/notification.go
@@ -31,7 +31,7 @@ type Notification struct {
 	RecommendRenew bool
 
 	// Set if there is no data pre-filled from processing the webhook. The
-	// handler is to call GetNofiticationData(), with the appropriate user
+	// handler is to call GetNotificationData(), with the appropriate user
 	// credentials.
 	IsBare bool
 }

--- a/msgraph/get_super_user_token.go
+++ b/msgraph/get_super_user_token.go
@@ -17,21 +17,14 @@ type AuthResponse struct {
 }
 
 func (c *client) GetSuperuserToken() (string, error) {
-	params := map[string]string{
-		"client_id":     c.conf.OAuth2ClientID,
-		"scope":         "https://graph.microsoft.com/.default",
-		"client_secret": c.conf.OAuth2ClientSecret,
-		"grant_type":    "client_credentials",
-	}
-
 	u := "https://login.microsoftonline.com/" + c.conf.OAuth2Authority + "/oauth2/v2.0/token"
 	res := AuthResponse{}
 
 	data := url.Values{}
-	data.Set("client_id", params["client_id"])
-	data.Set("scope", params["scope"])
-	data.Set("client_secret", params["client_secret"])
-	data.Set("grant_type", params["grant_type"])
+	data.Set("client_id", c.conf.OAuth2ClientID)
+	data.Set("scope", "https://graph.microsoft.com/.default")
+	data.Set("client_secret", c.conf.OAuth2ClientSecret)
+	data.Set("grant_type", "client_credentials")
 
 	_, err := c.CallFormPost(http.MethodPost, u, data, &res)
 	if err != nil {


### PR DESCRIPTION
#### Summary
- Fix typo `GetNotificationData()` in comment
- Fix typo "there's" in comment
- Fix typo "deactivated" in string
- Rename variable `command` to `cmd` to not collide with imported package
- Remove unnecessary variable `params` 

#### Ticket Link
NA

