### PR TITLE
[GH-367] Remove "prompt" param from auth code URL

### DIFF
--- a/calendar/engine/oauth2.go
+++ b/calendar/engine/oauth2.go
@@ -48,7 +48,7 @@ func (app *oauth2App) InitOAuth2(mattermostUserID string) (url string, err error
 		return "", err
 	}
 
-	return conf.AuthCodeURL(state, oauth2.AccessTypeOffline, oauth2.SetAuthURLParam("prompt", "consent")), nil
+	return conf.AuthCodeURL(state, oauth2.AccessTypeOffline), nil
 }
 
 func (app *oauth2App) CompleteOAuth2(authedUserID, code, state string) error {

--- a/calendar/engine/oauth2_test.go
+++ b/calendar/engine/oauth2_test.go
@@ -120,7 +120,7 @@ func TestInitOAuth2(t *testing.T) {
 				ss.EXPECT().LoadUser(fakeID).Return(nil, errors.New("remote user not found")).Times(1)
 				ss.EXPECT().StoreOAuth2State(gomock.Any()).Return(nil).Times(1)
 			},
-			expectURL: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize?access_type=offline&client_id=fakeclientid&prompt=consent&redirect_uri=http%3A%2F%2Flocalhost%2Foauth2%2Fcomplete&response_type=code&scope=offline_access+User.Read+Calendars.ReadWrite+Calendars.ReadWrite.Shared+MailboxSettings.Read%40mattermost.com",
+			expectURL: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize?access_type=offline&client_id=fakeclientid&redirect_uri=http%3A%2F%2Flocalhost%2Foauth2%2Fcomplete&response_type=code&scope=offline_access+User.Read+Calendars.ReadWrite+Calendars.ReadWrite.Shared+MailboxSettings.Read%40mattermost.com",
 		},
 	}
 


### PR DESCRIPTION
#### Summary
##### Issue:
- According to the [issue linked below](https://github.com/mattermost/mattermost-plugin-mscalendar/issues/367), the users are not able to accept the permissions in the modal. That modal [was not present](https://github.com/mattermost/mattermost-plugin-mscalendar/issues/367#issuecomment-2135402695) in the previous plugin release and the users were able to connect just by clicking the link from MM.
- The modal is occurring because of a [code change](https://github.com/mattermost/mattermost-plugin-mscalendar/blob/b4f752d6669a9958e7b7b16c757d2d1e5dc7f8a6/calendar/engine/oauth2.go#L51) in [this PR](https://github.com/mattermost/mattermost-plugin-mscalendar/pull/267/files). The [prompt param](https://pkg.go.dev/golang.org/x/oauth2@v0.15.0#section-readme) in the URL is forcing the users to accept the permission the oauth app is requesting on every connection.

##### Fix
- Remove "prompt" param from auth code URL.

#### Ticket Link
Fixes #367 

