### PR TITLE
[GH-394] Add timeout to http client

### DIFF
--- a/msgraph/remote.go
+++ b/msgraph/remote.go
@@ -53,7 +53,7 @@ func (r *impl) MakeClient(ctx context.Context, token *oauth2.Token) remote.Clien
 // MakeSuperuserClient creates a new client used for app-only permissions.
 func (r *impl) MakeSuperuserClient(ctx context.Context) (remote.Client, error) {
 	httpClient := &http.Client{
-		Timeout: time.Second * 5,
+		Timeout: time.Second * 60,
 	}
 	c := &client{
 		conf:       r.conf,

--- a/msgraph/remote.go
+++ b/msgraph/remote.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/microsoft"
@@ -51,7 +52,9 @@ func (r *impl) MakeClient(ctx context.Context, token *oauth2.Token) remote.Clien
 
 // MakeSuperuserClient creates a new client used for app-only permissions.
 func (r *impl) MakeSuperuserClient(ctx context.Context) (remote.Client, error) {
-	httpClient := &http.Client{}
+	httpClient := &http.Client{
+		Timeout: time.Second * 5,
+	}
 	c := &client{
 		conf:       r.conf,
 		ctx:        ctx,


### PR DESCRIPTION
#### Summary
- Add timeout to http client
- Http client has a [default timeout](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/methods-auto/httpclient/httpclient-timeout-method#remarks) of 100 sec. We updated it to ~5~ 60 sec.

#### Ticket Link
Fixes #394 
Fixes https://mattermost.atlassian.net/browse/MM-60185