### PR TITLE
[GH-395] Add path escaping to remote ID in getCalendarViewURL

### DIFF
--- a/msgraph/get_default_calendar_view.go
+++ b/msgraph/get_default_calendar_view.go
@@ -75,7 +75,7 @@ func (c *client) DoBatchViewCalendarRequests(allParams []*remote.ViewCalendarPar
 
 func getCalendarViewURL(params *remote.ViewCalendarParams) string {
 	paramStr := getQueryParamStringForCalendarView(params.StartTime, params.EndTime)
-	return "/Users/" + params.RemoteUserID + "/calendarView" + paramStr
+	return "/Users/" + url.PathEscape(params.RemoteUserID) + "/calendarView" + paramStr
 }
 
 func getQueryParamStringForCalendarView(start, end time.Time) string {


### PR DESCRIPTION
#### Summary
- Add path escaping to remote ID in getCalendarViewURL

#### Ticket Link
Fixes #395 
Fixes https://mattermost.atlassian.net/browse/MM-60182
