### PR TITLE
Escape string, fix comment, use constant

### DIFF
--- a/calendar/api/api.go
+++ b/calendar/api/api.go
@@ -46,6 +46,6 @@ func Init(h *httputils.Handler, env engine.Env, notificationProcessor engine.Not
 
 	// Returns provider information for the plugin to use
 	apiRoutes.HandleFunc(config.PathProvider, func(w http.ResponseWriter, r *http.Request) {
-		httputils.WriteJSONResponse(w, config.Provider, 200)
+		httputils.WriteJSONResponse(w, config.Provider, http.StatusOK)
 	})
 }

--- a/calendar/telemetry/logger.go
+++ b/calendar/telemetry/logger.go
@@ -85,7 +85,7 @@ func toKeyValuePairs(in map[string]interface{}) (out []interface{}) {
 }
 
 /*
-New creates a new logger.
+NewLogger creates a new logger.
 
 - api: LogAPI implementation
 */

--- a/msgraph/get_schedule_batched.go
+++ b/msgraph/get_schedule_batched.go
@@ -2,6 +2,7 @@ package msgraph
 
 import (
 	"net/http"
+	"net/url"
 
 	"github.com/pkg/errors"
 
@@ -81,7 +82,7 @@ func (c *client) GetSchedule(requests []*remote.ScheduleUserInfo, startTime, end
 }
 
 func makeSingleRequestForGetSchedule(request *remote.ScheduleUserInfo, params *getScheduleRequestParams) *singleRequest {
-	u := "/Users/" + request.RemoteUserID + "/getSchedule"
+	u := "/Users/" + url.PathEscape(request.RemoteUserID) + "/getSchedule"
 	req := &singleRequest{
 		URL:    u,
 		Method: http.MethodPost,


### PR DESCRIPTION
#### Summary
- Escape string in URL generation
- Fix doc comment
- Replace hard coded HTTP status code with constant

#### Ticket Link
NA

