### PR TITLE
Bump version to 1.3.4

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -4,9 +4,9 @@
     "description": "Microsoft Calendar Integration",
     "homepage_url": "https://mattermost.com/pl/mattermost-plugin-mscalendar",
     "support_url": "https://github.com/mattermost/mattermost-plugin-mscalendar/issues",
-    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-mscalendar/releases/tag/v1.3.2",
+    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-mscalendar/releases/tag/v1.3.4",
     "icon_path": "assets/profile-mscalendar.svg",
-    "version": "1.3.2",
+    "version": "1.3.4",
     "min_server_version": "8.1.0",
     "server": {
         "executables": {


### PR DESCRIPTION
#### Summary
Bumps plugin version to v1.3.4 to force internal plugin version, GH tag, and filename version are in sync.

#### Ticket Link
NONE