### PR TITLE
[MM-339]: Added support for lower case meridiems(AM/PM)

### DIFF
--- a/calendar/engine/daily_summary.go
+++ b/calendar/engine/daily_summary.go
@@ -5,6 +5,7 @@ package engine
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -44,7 +45,7 @@ func (m *mscalendar) SetDailySummaryPostTime(user *User, timeStr string) (*store
 		return nil, err
 	}
 
-	t, err := time.Parse(time.Kitchen, timeStr)
+	t, err := time.Parse(time.Kitchen, convertToUpperCaseTime(timeStr))
 	if err != nil {
 		return nil, errors.New("Invalid time value: " + timeStr)
 	}
@@ -290,4 +291,18 @@ func getTodayHoursForTimezone(now time.Time, timezone string) (start, end time.T
 	start = time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
 	end = start.Add(24 * time.Hour)
 	return start, end
+}
+
+func convertToUpperCaseTime(timeStr string) string {
+	if len(timeStr) < 2 {
+		return timeStr
+	}
+
+	period := timeStr[len(timeStr)-2:]
+
+	if strings.ToLower(period) == "am" || strings.ToLower(period) == "pm" {
+		return timeStr[:len(timeStr)-2] + strings.ToUpper(period)
+	}
+
+	return timeStr
 }


### PR DESCRIPTION
#### Summary
Added support for lowercase meridiems(AM/PM)

#### Ticket Link
  Fixes https://github.com/mattermost/mattermost-plugin-mscalendar/issues/339
  
 #### What to test
 `/mscalendar summary time 9:00AM` and `/mscalendar summary time 9:00am`

