### PR TITLE
[MM-340]: Improved the handling of all day event while rendering events

### DIFF
--- a/calendar/engine/views/calendar.go
+++ b/calendar/engine/views/calendar.go
@@ -151,6 +151,22 @@ func MarkdownToHTMLEntities(input string) string {
 }
 
 func renderEvent(event *remote.Event, asRow bool, timeZone string) (string, error) {
+	link, err := url.QueryUnescape(event.Weblink)
+	if err != nil {
+		return "", err
+	}
+
+	subject := EnsureSubject(event.Subject)
+
+	if event.IsAllDay {
+		format := "(All day event) [%s](%s)"
+		if asRow {
+			format = "| All day event | [%s](%s) |"
+		}
+
+		return fmt.Sprintf(format, MarkdownToHTMLEntities(subject), link), nil
+	}
+
 	start := event.Start.In(timeZone).Time().Format(time.Kitchen)
 	end := event.End.In(timeZone).Time().Format(time.Kitchen)
 
@@ -158,13 +174,6 @@ func renderEvent(event *remote.Event, asRow bool, timeZone string) (string, erro
 	if asRow {
 		format = "| %s - %s | [%s](%s) |"
 	}
-
-	link, err := url.QueryUnescape(event.Weblink)
-	if err != nil {
-		return "", err
-	}
-
-	subject := EnsureSubject(event.Subject)
 
 	return fmt.Sprintf(format, start, end, MarkdownToHTMLEntities(subject), link), nil
 }


### PR DESCRIPTION
#### Summary
Improved the handling of all-day events while rendering events
#### Screenshots
##### Old
![Screenshot from 2024-11-27 11-32-46](https://github.com/user-attachments/assets/a9c107f1-f042-474f-9d33-f352d6db49e5)
##### New
![Screenshot from 2024-11-27 11-32-59](https://github.com/user-attachments/assets/04da01fd-d120-4d23-9563-11ed2a83e7db)
#### Ticket Link
  Fixes https://github.com/mattermost/mattermost-plugin-mscalendar/issues/340
  #### What to test
  - Create an all-day event and check its rendering on MM
