### PR TITLE
Fix bugs reported by QA on v1.4.0-rc2

### DIFF
--- a/calendar/engine/daily_summary.go
+++ b/calendar/engine/daily_summary.go
@@ -335,7 +335,11 @@ func convertMeridiemToUpperCase(timeStr string) string {
 	}
 
 	// Normalize minute to 2-digit by trimming and converting
-	minuteInt, err := strconv.Atoi(strings.TrimLeft(parts[1], "0"))
+	minuteRaw := strings.TrimLeft(parts[1], "0")
+	if minuteRaw == "" {
+		minuteRaw = "0"
+	}
+	minuteInt, err := strconv.Atoi(minuteRaw)
 	if err != nil {
 		return timeStr // invalid minute format
 	}

--- a/calendar/engine/daily_summary.go
+++ b/calendar/engine/daily_summary.go
@@ -300,7 +300,11 @@ func convertMeridiemToUpperCase(timeStr string) string {
 		return timeStr
 	}
 
-	meridiem := strings.ToUpper(timeStr[len(timeStr)-2:])
+	if timeStr[0] == '0' { // check and remove zero from the start of the string
+		timeStr = timeStr[1:]
+	}
+
+	meridiem := strings.ToUpper(timeStr[len(timeStr)-2:]) // extracting last 2 characters of time string and converting it to upper case
 
 	if meridiem == "AM" || meridiem == "PM" {
 		return timeStr[:len(timeStr)-2] + meridiem

--- a/calendar/engine/daily_summary.go
+++ b/calendar/engine/daily_summary.go
@@ -313,7 +313,7 @@ convertMeridiemToUpperCase normalizes time strings to the "H:MMAM" or "H:MMPM" f
   - Invalid times like "25:61am" or "abc" — returned as-is without modification
 */
 func convertMeridiemToUpperCase(timeStr string) string {
-	if len(timeStr) < 6 { // Too short to be valid
+	if len(timeStr) < 5 { // Too short to be valid. Shortest supported string is of type '1:5am', that will be converted to '1:05AM'
 		return timeStr
 	}
 

--- a/calendar/engine/daily_summary.go
+++ b/calendar/engine/daily_summary.go
@@ -5,6 +5,7 @@ package engine
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -333,12 +334,12 @@ func convertMeridiemToUpperCase(timeStr string) string {
 		hour = "0"
 	}
 
-	// Strip leading zeros from minute and ensure it's 2 digits
-	minuteRaw := strings.TrimLeft(parts[1], "0")
-	if minuteRaw == "" {
-		minuteRaw = "0"
+	// Normalize minute to 2-digit by trimming and converting
+	minuteInt, err := strconv.Atoi(strings.TrimLeft(parts[1], "0"))
+	if err != nil {
+		return timeStr // invalid minute format
 	}
-	minute := fmt.Sprintf("%02s", minuteRaw) // Ensure minute is always 2 characters wide by padding with leading zero if needed
+	minute := fmt.Sprintf("%02d", minuteInt) // Ensure 2-digit minute
 
 	return hour + ":" + minute + meridiem
 }

--- a/calendar/engine/daily_summary_test.go
+++ b/calendar/engine/daily_summary_test.go
@@ -562,7 +562,7 @@ func TestSetDailySummaryPostTime(t *testing.T) {
 	}{
 		{
 			name:       "error filtering with user",
-			timeString: "9:00 AM",
+			timeString: "9:00AM",
 			user:       GetMockUser(nil, nil, MockMMUserID, nil),
 			setupMock: func() {
 				mockStore.EXPECT().LoadUser(MockMMUserID).Return(nil, errors.New("error filtering user")).Times(1)
@@ -574,25 +574,25 @@ func TestSetDailySummaryPostTime(t *testing.T) {
 		},
 		{
 			name:       "invalid time format",
-			timeString: "invalid time",
+			timeString: "9:05 AM",
 			user:       GetMockUser(nil, nil, MockMMUserID, GetMockStoreSettings()),
 			setupMock: func() {
 				mockPluginAPI.EXPECT().GetMattermostUser(MockMMUserID)
 			},
 			assertion: func(t *testing.T, settings *store.DailySummaryUserSettings, err error) {
-				require.EqualError(t, err, "Invalid time value: invalid time")
+				require.EqualError(t, err, "Invalid time value: 9:05 AM")
 				require.Nil(t, settings)
 			},
 		},
 		{
 			name:       "time not a multiple of interval",
-			timeString: "9:05 AM",
+			timeString: "9:05AM",
 			user:       GetMockUserWithDefaultDailySummaryUserSettings(),
 			setupMock: func() {
 				mockPluginAPI.EXPECT().GetMattermostUser(MockMMUserID)
 			},
 			assertion: func(t *testing.T, settings *store.DailySummaryUserSettings, err error) {
-				require.EqualError(t, err, "Invalid time value: 9:05 AM")
+				require.EqualError(t, err, "time must be a multiple of 15 minutes")
 				require.Nil(t, settings)
 			},
 		},

--- a/calendar/engine/notification_format.go
+++ b/calendar/engine/notification_format.go
@@ -25,8 +25,8 @@ func (processor *notificationProcessor) newSlackAttachment(n *remote.Notificatio
 		AuthorLink: "mailto:" + n.Event.Organizer.EmailAddress.Address,
 		TitleLink:  titleLink,
 		Title:      title,
-		Text:       text,
-		Fallback:   fmt.Sprintf("[%s](%s): %s", title, titleLink, text),
+		Text:       views.MarkdownToHTMLEntities(text),
+		Fallback:   fmt.Sprintf("[%s](%s): %s", title, titleLink, views.MarkdownToHTMLEntities(text)),
 	}
 }
 
@@ -223,15 +223,15 @@ func eventToFields(e *remote.Event, timezone string) fields.Fields {
 	}
 
 	ff := fields.Fields{
-		FieldSubject:     fields.NewStringValue(views.EnsureSubject(e.Subject)),
-		FieldBodyPreview: fields.NewStringValue(valueOrNotDefined(e.BodyPreview)),
+		FieldSubject:     fields.NewStringValue(views.MarkdownToHTMLEntities(views.EnsureSubject(e.Subject))),
+		FieldBodyPreview: fields.NewStringValue(views.MarkdownToHTMLEntities(valueOrNotDefined(e.BodyPreview))),
 		FieldImportance:  fields.NewStringValue(valueOrNotDefined(e.Importance)),
 		FieldWhen:        fields.NewStringValue(valueOrNotDefined(formattedDate)),
 		FieldDuration:    fields.NewStringValue(valueOrNotDefined(dur)),
 		FieldOrganizer: fields.NewStringValue(
 			fmt.Sprintf("[%s](mailto:%s)",
 				e.Organizer.EmailAddress.Name, e.Organizer.EmailAddress.Address)),
-		FieldLocation:       fields.NewStringValue(valueOrNotDefined(e.Location.DisplayName)),
+		FieldLocation:       fields.NewStringValue(views.MarkdownToHTMLEntities(valueOrNotDefined(e.Location.DisplayName))),
 		FieldResponseStatus: fields.NewStringValue(e.ResponseStatus.Response),
 		FieldAttendees:      fields.NewMultiValue(attendees...),
 	}

--- a/calendar/engine/views/calendar.go
+++ b/calendar/engine/views/calendar.go
@@ -96,7 +96,7 @@ func RenderDaySummary(events []*remote.Event, timezone string) (string, []*model
 		if event.Location != nil && event.Location.DisplayName != "" {
 			fields = append(fields, &model.SlackAttachmentField{
 				Title: "Location",
-				Value: event.Location.DisplayName,
+				Value: MarkdownToHTMLEntities(event.Location.DisplayName),
 				Short: true,
 			})
 		}
@@ -189,7 +189,7 @@ func RenderEventAsAttachment(event *remote.Event, timezone string, options ...Op
 	if event.Location != nil && event.Location.DisplayName != "" {
 		fields = append(fields, &model.SlackAttachmentField{
 			Title: "Location",
-			Value: event.Location.DisplayName,
+			Value: MarkdownToHTMLEntities(event.Location.DisplayName),
 			Short: true,
 		})
 	}
@@ -216,7 +216,7 @@ func RenderEventAsAttachment(event *remote.Event, timezone string, options ...Op
 		Text:      fmt.Sprintf("%s - %s", event.Start.In(timezone).Time().Format(time.Kitchen), event.End.In(timezone).Time().Format(time.Kitchen)),
 		Fields:    fields,
 		Actions:   actions,
-		Fallback:  fmt.Sprintf("%s\n%s - %s", event.Subject, event.Start.In(timezone).Time().Format(time.Kitchen), event.End.In(timezone).Time().Format(time.Kitchen)),
+		Fallback:  fmt.Sprintf("%s\n%s - %s", MarkdownToHTMLEntities(event.Subject), event.Start.In(timezone).Time().Format(time.Kitchen), event.End.In(timezone).Time().Format(time.Kitchen)),
 	}
 
 	for _, opt := range options {


### PR DESCRIPTION
#### Summary
- Fix issue of `01:25AM` not being treated as valid time entry for hours
-  Replaced chars with HTML entities in reminder posts for location, description and other fields

#### Ticket Link
 Fixes https://github.com/mattermost/mattermost-plugin-mscalendar/issues/457
 Fixes https://github.com/mattermost/mattermost-plugin-mscalendar/issues/455