### PR TITLE
MM-67613 EncryptionKey rotation enhancements

### DIFF
--- a/calendar/engine/user.go
+++ b/calendar/engine/user.go
@@ -134,7 +134,17 @@ func (m *mscalendar) DisconnectUser(mattermostUserID string) error {
 
 	storedUser, err := m.Store.LoadUser(mattermostUserID)
 	if err != nil {
-		return err
+		if err == store.ErrNotFound {
+			return err
+		}
+
+		// Fall back to force-deleting using the unencrypted user index.
+		m.Logger.Warnf("failed to load user %s during disconnect, attempting force-delete: %v", mattermostUserID, err)
+		indexUser, indexErr := m.Store.LoadUserFromIndex(mattermostUserID)
+		if indexErr != nil {
+			return errors.Wrap(err, "unable to load user for disconnect")
+		}
+		return m.Store.ForceDeleteUser(mattermostUserID, indexUser.RemoteID)
 	}
 
 	// Unlink events owned by the user that is disconnecting its account

--- a/calendar/engine/user.go
+++ b/calendar/engine/user.go
@@ -142,7 +142,7 @@ func (m *mscalendar) DisconnectUser(mattermostUserID string) error {
 		m.Logger.Warnf("failed to load user %s during disconnect, attempting force-delete: %v", mattermostUserID, err)
 		indexUser, indexErr := m.Store.LoadUserFromIndex(mattermostUserID)
 		if indexErr != nil {
-			return errors.Wrap(err, "unable to load user for disconnect")
+			return errors.Wrapf(err, "unable to load user for disconnect (index lookup also failed: %v)", indexErr)
 		}
 		return m.Store.ForceDeleteUser(mattermostUserID, indexUser.RemoteID)
 	}

--- a/calendar/engine/user_test.go
+++ b/calendar/engine/user_test.go
@@ -321,15 +321,48 @@ func TestDisconnectUser(t *testing.T) {
 			},
 		},
 		{
-			name: "error loading the user",
+			name: "error loading the user - not found",
 			setupMock: func() {
 				mscalendar.client = mockClient
 				mscalendar.actingUser = &User{MattermostUserID: MockRemoteUserID}
 				mockWelcomer.EXPECT().AfterDisconnect(MockMMUserID).Return(nil).Times(1)
-				mockStore.EXPECT().LoadUser(MockMMUserID).Return(nil, errors.New("error loading the user")).Times(1)
+				mockStore.EXPECT().LoadUser(MockMMUserID).Return(nil, store.ErrNotFound).Times(1)
 			},
 			assertions: func(err error) {
-				require.EqualError(t, err, "error loading the user")
+				require.ErrorIs(t, err, store.ErrNotFound)
+			},
+		},
+		{
+			name: "error loading the user - decryption error, fallback to force-delete succeeds",
+			setupMock: func() {
+				mscalendar.client = mockClient
+				mscalendar.actingUser = &User{MattermostUserID: MockRemoteUserID}
+				mockWelcomer.EXPECT().AfterDisconnect(MockMMUserID).Return(nil).Times(1)
+				mockStore.EXPECT().LoadUser(MockMMUserID).Return(nil, errors.New("cipher: message authentication failed")).Times(1)
+				mockLogger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+				mockStore.EXPECT().LoadUserFromIndex(MockMMUserID).Return(&store.UserShort{
+					MattermostUserID: MockMMUserID,
+					RemoteID:         MockRemoteUserID,
+				}, nil).Times(1)
+				mockStore.EXPECT().ForceDeleteUser(MockMMUserID, MockRemoteUserID).Return(nil).Times(1)
+			},
+			assertions: func(err error) {
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "error loading the user - decryption error, fallback fails on index lookup",
+			setupMock: func() {
+				mscalendar.client = mockClient
+				mscalendar.actingUser = &User{MattermostUserID: MockRemoteUserID}
+				mockWelcomer.EXPECT().AfterDisconnect(MockMMUserID).Return(nil).Times(1)
+				mockStore.EXPECT().LoadUser(MockMMUserID).Return(nil, errors.New("cipher: message authentication failed")).Times(1)
+				mockLogger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+				mockStore.EXPECT().LoadUserFromIndex(MockMMUserID).Return(nil, store.ErrNotFound).Times(1)
+			},
+			assertions: func(err error) {
+				require.Error(t, err)
+				require.ErrorContains(t, err, "unable to load user for disconnect")
 			},
 		},
 		{

--- a/calendar/engine/user_test.go
+++ b/calendar/engine/user_test.go
@@ -363,6 +363,7 @@ func TestDisconnectUser(t *testing.T) {
 			assertions: func(err error) {
 				require.Error(t, err)
 				require.ErrorContains(t, err, "unable to load user for disconnect")
+				require.ErrorContains(t, err, "index lookup also failed")
 			},
 		},
 		{

--- a/calendar/plugin/plugin.go
+++ b/calendar/plugin/plugin.go
@@ -344,18 +344,8 @@ func (p *Plugin) loadTemplates(bundlePath string) error {
 }
 
 // reEncryptUserData re-encrypts all user data when the encryption key changes.
-// It creates a temporary store with the old key to read user records, then
-// writes them back through the new store (which encrypts with the new key).
-// This is fully transparent to users — all settings, tokens, and linked data
-// are preserved. If a user's record cannot be decrypted with the old key, it
-// falls back to force-deleting their data and notifying them to reconnect.
-//
-// Note on orphaned data: when a user can't be decrypted, the subscription ID
-// and linked event IDs are locked inside the unreadable record, so we cannot
-// clean them up. These records self-expire via TTLs (subscriptions expire on
-// the remote side, events via ttlAfterEventEnd). When re-encryption itself
-// fails (StoreUser error), we still have the decrypted user and clean up its
-// subscription and linked events before deleting.
+// Users whose records can't be decrypted with the old key are force-deleted
+// and notified to reconnect.
 func (p *Plugin) reEncryptUserData(e *Env, previousEncryptionKey string) {
 	userIndex, err := e.Dependencies.Store.LoadUserIndex()
 	if err != nil {
@@ -400,9 +390,7 @@ func (p *Plugin) reEncryptUserData(e *Env, previousEncryptionKey string) {
 }
 
 // cleanupUserRelatedData removes subscription and linked event data for a user
-// whose re-encryption failed, then force-deletes the core user records. This
-// requires the decrypted user to be available so we can read the subscription
-// ID and linked event IDs.
+// whose re-encryption failed, then force-deletes the core user records.
 func (p *Plugin) cleanupUserRelatedData(e *Env, user *store.User, indexEntry *store.UserShort) {
 	if subID := user.Settings.EventSubscriptionID; subID != "" {
 		if err := e.Dependencies.Store.DeleteUserSubscription(user, subID); err != nil {

--- a/calendar/plugin/plugin.go
+++ b/calendar/plugin/plugin.go
@@ -165,6 +165,8 @@ func (p *Plugin) OnConfigurationChange() (err error) {
 	pluginURLPath := "/plugins/" + url.PathEscape(env.Config.PluginID)
 	pluginURL := strings.TrimRight(*mattermostSiteURL, "/") + pluginURLPath
 
+	previousEncryptionKey := env.Config.EncryptionKey
+
 	p.updateEnv(func(e *Env) {
 		p.initEnv(e, pluginURL)
 
@@ -202,6 +204,11 @@ func (p *Plugin) OnConfigurationChange() (err error) {
 		e.Dependencies.Poster = e.bot
 		e.Dependencies.Welcomer = mscalendarBot
 		e.Dependencies.Store = store.NewPluginStore(p.API, e.bot, e.bot, e.Dependencies.Tracker, e.Provider.Features.EncryptedStore, []byte(e.EncryptionKey))
+
+		if e.Provider.Features.EncryptedStore && previousEncryptionKey != "" && previousEncryptionKey != stored.EncryptionKey {
+			p.reEncryptUserData(e, previousEncryptionKey)
+		}
+
 		e.Dependencies.SettingsPanel = engine.NewSettingsPanel(
 			e.bot,
 			e.Dependencies.Store,
@@ -334,6 +341,106 @@ func (p *Plugin) loadTemplates(bundlePath string) error {
 	}
 	p.Templates = templates
 	return nil
+}
+
+// reEncryptUserData re-encrypts all user data when the encryption key changes.
+// It creates a temporary store with the old key to read user records, then
+// writes them back through the new store (which encrypts with the new key).
+// This is fully transparent to users — all settings, tokens, and linked data
+// are preserved. If a user's record cannot be decrypted with the old key, it
+// falls back to force-deleting their data and notifying them to reconnect.
+//
+// Note on orphaned data: when a user can't be decrypted, the subscription ID
+// and linked event IDs are locked inside the unreadable record, so we cannot
+// clean them up. These records self-expire via TTLs (subscriptions expire on
+// the remote side, events via ttlAfterEventEnd). When re-encryption itself
+// fails (StoreUser error), we still have the decrypted user and clean up its
+// subscription and linked events before deleting.
+func (p *Plugin) reEncryptUserData(e *Env, previousEncryptionKey string) {
+	userIndex, err := e.Dependencies.Store.LoadUserIndex()
+	if err != nil {
+		p.API.LogWarn("Encryption key changed but failed to load user index for re-encryption", "error", err.Error())
+		return
+	}
+
+	if len(userIndex) == 0 {
+		return
+	}
+
+	p.API.LogInfo("Encryption key changed, re-encrypting user data", "user_count", fmt.Sprintf("%d", len(userIndex)))
+
+	oldKeyStore := store.NewPluginStore(p.API, e.bot, e.bot, e.Dependencies.Tracker, true, []byte(previousEncryptionKey))
+
+	for _, u := range userIndex {
+		oldUser, loadErr := oldKeyStore.LoadUser(u.MattermostUserID)
+		if loadErr != nil {
+			p.API.LogWarn("Could not decrypt user with previous encryption key, force-deleting",
+				"mm_user_id", u.MattermostUserID,
+				"error", loadErr.Error(),
+			)
+			if delErr := e.Dependencies.Store.ForceDeleteUser(u.MattermostUserID, u.RemoteID); delErr != nil {
+				p.API.LogWarn("Failed to force-delete user during encryption key rotation",
+					"mm_user_id", u.MattermostUserID,
+					"error", delErr.Error(),
+				)
+			}
+			p.notifyUserReconnect(e, u.MattermostUserID, "the plugin encryption key was changed")
+			continue
+		}
+
+		if storeErr := e.Dependencies.Store.StoreUser(oldUser); storeErr != nil {
+			p.API.LogWarn("Failed to re-encrypt user data with new key, force-deleting",
+				"mm_user_id", u.MattermostUserID,
+				"error", storeErr.Error(),
+			)
+			p.cleanupUserRelatedData(e, oldUser, u)
+			p.notifyUserReconnect(e, u.MattermostUserID, "the plugin encryption key was changed and your data could not be migrated")
+		}
+	}
+}
+
+// cleanupUserRelatedData removes subscription and linked event data for a user
+// whose re-encryption failed, then force-deletes the core user records. This
+// requires the decrypted user to be available so we can read the subscription
+// ID and linked event IDs.
+func (p *Plugin) cleanupUserRelatedData(e *Env, user *store.User, indexEntry *store.UserShort) {
+	if subID := user.Settings.EventSubscriptionID; subID != "" {
+		if err := e.Dependencies.Store.DeleteUserSubscription(user, subID); err != nil {
+			p.API.LogWarn("Failed to delete subscription during encryption key rotation",
+				"mm_user_id", user.MattermostUserID,
+				"subscription_id", subID,
+				"error", err.Error(),
+			)
+		}
+	}
+
+	for eventID, channelID := range user.ChannelEvents {
+		if err := e.Dependencies.Store.DeleteLinkedChannelFromEvent(eventID, channelID); err != nil {
+			p.API.LogWarn("Failed to unlink channel event during encryption key rotation",
+				"mm_user_id", user.MattermostUserID,
+				"event_id", eventID,
+				"error", err.Error(),
+			)
+		}
+	}
+
+	if delErr := e.Dependencies.Store.ForceDeleteUser(indexEntry.MattermostUserID, indexEntry.RemoteID); delErr != nil {
+		p.API.LogWarn("Failed to force-delete user during encryption key rotation",
+			"mm_user_id", indexEntry.MattermostUserID,
+			"error", delErr.Error(),
+		)
+	}
+}
+
+func (p *Plugin) notifyUserReconnect(e *Env, mattermostUserID, reason string) {
+	msg := fmt.Sprintf("Your %s connection has been reset because %s. Please reconnect using `/%s connect`.",
+		config.Provider.DisplayName, reason, config.Provider.CommandTrigger)
+	if _, dmErr := e.bot.DM(mattermostUserID, msg); dmErr != nil {
+		p.API.LogWarn("Failed to notify user about encryption key change",
+			"mm_user_id", mattermostUserID,
+			"error", dmErr.Error(),
+		)
+	}
 }
 
 func (p *Plugin) initEnv(e *Env, pluginURL string) error {

--- a/calendar/store/mock_store/mock_store.go
+++ b/calendar/store/mock_store/mock_store.go
@@ -133,6 +133,20 @@ func (mr *MockStoreMockRecorder) DeleteUser(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUser", reflect.TypeOf((*MockStore)(nil).DeleteUser), arg0)
 }
 
+// ForceDeleteUser mocks base method.
+func (m *MockStore) ForceDeleteUser(arg0, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ForceDeleteUser", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ForceDeleteUser indicates an expected call of ForceDeleteUser.
+func (mr *MockStoreMockRecorder) ForceDeleteUser(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForceDeleteUser", reflect.TypeOf((*MockStore)(nil).ForceDeleteUser), arg0, arg1)
+}
+
 // DeleteUserEvent mocks base method.
 func (m *MockStore) DeleteUserEvent(arg0, arg1 string) error {
 	m.ctrl.T.Helper()

--- a/calendar/store/user_store.go
+++ b/calendar/store/user_store.go
@@ -232,8 +232,12 @@ func (s *pluginStore) DeleteUser(mattermostUserID string) error {
 // the user record first. This is used when the encryption key has changed and
 // the stored user data can no longer be decrypted.
 func (s *pluginStore) ForceDeleteUser(mattermostUserID, remoteUserID string) error {
-	_ = s.userKV.Delete(mattermostUserID)
-	_ = s.mattermostUserIDKV.Delete(remoteUserID)
+	if err := s.userKV.Delete(mattermostUserID); err != nil {
+		s.Logger.Warnf("ForceDeleteUser: failed to delete user KV for %s: %v", mattermostUserID, err)
+	}
+	if err := s.mattermostUserIDKV.Delete(remoteUserID); err != nil {
+		s.Logger.Warnf("ForceDeleteUser: failed to delete mmuid KV for %s: %v", remoteUserID, err)
+	}
 	return s.DeleteUserFromIndex(mattermostUserID)
 }
 

--- a/calendar/store/user_store.go
+++ b/calendar/store/user_store.go
@@ -34,6 +34,7 @@ type UserStore interface {
 	StoreUser(user *User) error
 	LoadUserFromIndex(mattermostUserID string) (*UserShort, error)
 	DeleteUser(mattermostUserID string) error
+	ForceDeleteUser(mattermostUserID, remoteUserID string) error
 	GetConnectedUserCount() (uint64, error)
 	ModifyUserIndex(modify func(userIndex UserIndex) (UserIndex, error)) error
 	StoreUserInIndex(user *User) error
@@ -225,6 +226,15 @@ func (s *pluginStore) DeleteUser(mattermostUserID string) error {
 	}
 
 	return nil
+}
+
+// ForceDeleteUser removes user data by key without needing to load/decrypt
+// the user record first. This is used when the encryption key has changed and
+// the stored user data can no longer be decrypted.
+func (s *pluginStore) ForceDeleteUser(mattermostUserID, remoteUserID string) error {
+	_ = s.userKV.Delete(mattermostUserID)
+	_ = s.mattermostUserIDKV.Delete(remoteUserID)
+	return s.DeleteUserFromIndex(mattermostUserID)
 }
 
 func (s *pluginStore) GetConnectedUserCount() (uint64, error) {

--- a/calendar/store/user_store_test.go
+++ b/calendar/store/user_store_test.go
@@ -6,10 +6,12 @@ package store
 import (
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/testutil"
+	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/utils/bot/mock_bot"
 	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/utils/kvstore"
 
 	"github.com/mattermost/mattermost/server/public/model"
@@ -330,14 +332,15 @@ func TestDeleteUser(t *testing.T) {
 func TestForceDeleteUser(t *testing.T) {
 	tests := []struct {
 		name       string
-		setup      func(*testutil.MockPluginAPI)
+		setup      func(*testutil.MockPluginAPI, *mock_bot.MockLogger)
 		assertions func(*testing.T, error)
 	}{
 		{
 			name: "Success force-deleting user even if KVDelete calls fail for user and mmuid",
-			setup: func(mockAPI *testutil.MockPluginAPI) {
+			setup: func(mockAPI *testutil.MockPluginAPI, mockLogger *mock_bot.MockLogger) {
 				mockAPI.On("KVDelete", "user_c3b5020d58a049787bc969768465b890").Return(&model.AppError{Message: "delete failed"})
 				mockAPI.On("KVDelete", "mmuid_e138a0f218087f9324d8c77f87d5f3a0").Return(&model.AppError{Message: "delete failed"})
+				mockLogger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any()).Times(2)
 				mockAPI.On("KVGet", "userindex_").Return([]byte(MockUserIndexJSON), nil).Times(1)
 				mockAPI.On("KVSetWithOptions", "userindex_", mock.Anything, mock.Anything).Return(true, nil).Times(1)
 			},
@@ -347,7 +350,7 @@ func TestForceDeleteUser(t *testing.T) {
 		},
 		{
 			name: "Success force-deleting user",
-			setup: func(mockAPI *testutil.MockPluginAPI) {
+			setup: func(mockAPI *testutil.MockPluginAPI, mockLogger *mock_bot.MockLogger) {
 				mockAPI.On("KVDelete", "user_c3b5020d58a049787bc969768465b890").Return(nil)
 				mockAPI.On("KVDelete", "mmuid_e138a0f218087f9324d8c77f87d5f3a0").Return(nil)
 				mockAPI.On("KVGet", "userindex_").Return([]byte(MockUserIndexJSON), nil).Times(1)
@@ -359,7 +362,7 @@ func TestForceDeleteUser(t *testing.T) {
 		},
 		{
 			name: "Error deleting user from index propagates",
-			setup: func(mockAPI *testutil.MockPluginAPI) {
+			setup: func(mockAPI *testutil.MockPluginAPI, mockLogger *mock_bot.MockLogger) {
 				mockAPI.On("KVDelete", "user_c3b5020d58a049787bc969768465b890").Return(nil)
 				mockAPI.On("KVDelete", "mmuid_e138a0f218087f9324d8c77f87d5f3a0").Return(nil)
 				mockAPI.On("KVGet", "userindex_").Return(nil, &model.AppError{Message: "KVGet failed"}).Times(1)
@@ -372,8 +375,8 @@ func TestForceDeleteUser(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockAPI, store, _, _, _ := GetMockSetup(t)
-			tt.setup(mockAPI)
+			mockAPI, store, mockLogger, _, _ := GetMockSetup(t)
+			tt.setup(mockAPI, mockLogger)
 
 			err := store.ForceDeleteUser(MockMMUserID, MockRemoteID)
 

--- a/calendar/store/user_store_test.go
+++ b/calendar/store/user_store_test.go
@@ -327,6 +327,62 @@ func TestDeleteUser(t *testing.T) {
 	}
 }
 
+func TestForceDeleteUser(t *testing.T) {
+	tests := []struct {
+		name       string
+		setup      func(*testutil.MockPluginAPI)
+		assertions func(*testing.T, error)
+	}{
+		{
+			name: "Success force-deleting user even if KVDelete calls fail for user and mmuid",
+			setup: func(mockAPI *testutil.MockPluginAPI) {
+				mockAPI.On("KVDelete", "user_c3b5020d58a049787bc969768465b890").Return(&model.AppError{Message: "delete failed"})
+				mockAPI.On("KVDelete", "mmuid_e138a0f218087f9324d8c77f87d5f3a0").Return(&model.AppError{Message: "delete failed"})
+				mockAPI.On("KVGet", "userindex_").Return([]byte(MockUserIndexJSON), nil).Times(1)
+				mockAPI.On("KVSetWithOptions", "userindex_", mock.Anything, mock.Anything).Return(true, nil).Times(1)
+			},
+			assertions: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "Success force-deleting user",
+			setup: func(mockAPI *testutil.MockPluginAPI) {
+				mockAPI.On("KVDelete", "user_c3b5020d58a049787bc969768465b890").Return(nil)
+				mockAPI.On("KVDelete", "mmuid_e138a0f218087f9324d8c77f87d5f3a0").Return(nil)
+				mockAPI.On("KVGet", "userindex_").Return([]byte(MockUserIndexJSON), nil).Times(1)
+				mockAPI.On("KVSetWithOptions", "userindex_", mock.Anything, mock.Anything).Return(true, nil).Times(1)
+			},
+			assertions: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "Error deleting user from index propagates",
+			setup: func(mockAPI *testutil.MockPluginAPI) {
+				mockAPI.On("KVDelete", "user_c3b5020d58a049787bc969768465b890").Return(nil)
+				mockAPI.On("KVDelete", "mmuid_e138a0f218087f9324d8c77f87d5f3a0").Return(nil)
+				mockAPI.On("KVGet", "userindex_").Return(nil, &model.AppError{Message: "KVGet failed"}).Times(1)
+			},
+			assertions: func(t *testing.T, err error) {
+				require.Error(t, err)
+				require.ErrorContains(t, err, "KVGet failed")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockAPI, store, _, _, _ := GetMockSetup(t)
+			tt.setup(mockAPI)
+
+			err := store.ForceDeleteUser(MockMMUserID, MockRemoteID)
+
+			tt.assertions(t, err)
+			mockAPI.AssertExpectations(t)
+		})
+	}
+}
+
 func TestGetConnectedUserCount(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR improves the resilience of encryption key rotation by:
1. Adding logic that will re-encrypt stored data with new values if rotation is intercepted by OnConfigurationChanged
2. Fixing issue where users get locked in limbo, unable to disconnect their accounts or create a new connection

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://mattermost.atlassian.net/browse/MM-67613

#### QA Notes
Testing this will require a custom build of Google Calendar that uses the changes in here included in its build. Please contact me for the plugin build

1. Install the Google Calendar plugin in a fresh instance and complete its setup
2. Connect an account to the plugin
3. Enter the System Console and regenerate the Encryption Key value 
4. Confirm that the plugin can continue to be used normally by the user (`/gcal today` and any other commands run normally)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added encryption key rotation support to automatically re-encrypt user data when encryption keys change.
  * Introduced force-delete capability for user cleanup operations.

* **Bug Fixes**
  * Improved user disconnection reliability with fallback mechanism when standard loading fails.

* **Tests**
  * Added comprehensive test coverage for new force-delete and key rotation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->