### PR TITLE
MM-67945 Added config and flag to control force oauth consent

### DIFF
--- a/calendar/config/config.go
+++ b/calendar/config/config.go
@@ -13,6 +13,7 @@ type StoredConfig struct {
 	OAuth2Authority    string
 	OAuth2ClientID     string
 	OAuth2ClientSecret string
+	OAuth2ForceConsent bool
 	bot.Config
 	EnableStatusSync   bool
 	EnableDailySummary bool
@@ -30,6 +31,11 @@ type ProviderFeatures struct {
 
 	// MM-66824 - Hiding create event command until it's implemented for MS Calendar
 	HideCreateEventFromCommand bool
+
+	// ForceOAuth2Consent forces the consent prompt on every OAuth2 authorization,
+	// regardless of the OAuth2ForceConsent admin setting. Use for providers that
+	// require user consent to issue a refresh token (e.g. Google OAuth2).
+	ForceOAuth2Consent bool
 }
 
 // ProviderConfig represents the specific configuration that changes when building for different

--- a/calendar/engine/oauth2.go
+++ b/calendar/engine/oauth2.go
@@ -48,7 +48,12 @@ func (app *oauth2App) InitOAuth2(mattermostUserID string) (url string, err error
 		return "", err
 	}
 
-	return conf.AuthCodeURL(state, oauth2.AccessTypeOffline, oauth2.ApprovalForce), nil
+	opts := []oauth2.AuthCodeOption{oauth2.AccessTypeOffline}
+	if app.Config.OAuth2ForceConsent || app.Config.Provider.Features.ForceOAuth2Consent {
+		opts = append(opts, oauth2.ApprovalForce)
+	}
+
+	return conf.AuthCodeURL(state, opts...), nil
 }
 
 func (app *oauth2App) CompleteOAuth2(authedUserID, code, state string) error {

--- a/calendar/engine/oauth2_test.go
+++ b/calendar/engine/oauth2_test.go
@@ -98,6 +98,7 @@ func TestInitOAuth2(t *testing.T) {
 		mattermostUserID string
 		expectURL        string
 		expectError      bool
+		forceConsent     bool
 	}{
 		{
 			name:             "MM user already connected",
@@ -120,8 +121,9 @@ func TestInitOAuth2(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name:             "successful redirect",
+			name:             "successful redirect with force consent",
 			mattermostUserID: fakeID,
+			forceConsent:     true,
 			setup: func(d *Dependencies) {
 				ss := d.Store.(*mock_store.MockStore)
 				ss.EXPECT().LoadUser(fakeID).Return(nil, errors.New("remote user not found")).Times(1)
@@ -129,11 +131,23 @@ func TestInitOAuth2(t *testing.T) {
 			},
 			expectURL: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize?access_type=offline&client_id=fakeclientid&prompt=consent&redirect_uri=http%3A%2F%2Flocalhost%2Foauth2%2Fcomplete&response_type=code&scope=offline_access+User.Read+Calendars.ReadWrite+Calendars.ReadWrite.Shared+MailboxSettings.Read%40mattermost.com",
 		},
+		{
+			name:             "successful redirect without force consent",
+			mattermostUserID: fakeID,
+			forceConsent:     false,
+			setup: func(d *Dependencies) {
+				ss := d.Store.(*mock_store.MockStore)
+				ss.EXPECT().LoadUser(fakeID).Return(nil, errors.New("remote user not found")).Times(1)
+				ss.EXPECT().StoreOAuth2State(gomock.Any()).Return(nil).Times(1)
+			},
+			expectURL: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize?access_type=offline&client_id=fakeclientid&redirect_uri=http%3A%2F%2Flocalhost%2Foauth2%2Fcomplete&response_type=code&scope=offline_access+User.Read+Calendars.ReadWrite+Calendars.ReadWrite.Shared+MailboxSettings.Read%40mattermost.com",
+		},
 	}
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			app, env := newOAuth2TestApp(ctrl)
+			env.Config.OAuth2ForceConsent = tc.forceConsent
 			if tc.setup != nil {
 				tc.setup(env.Dependencies)
 			}

--- a/plugin.json
+++ b/plugin.json
@@ -90,6 +90,14 @@
                 "placeholder": "",
                 "default": "",
                 "secret": true
+            },
+            {
+                "key": "OAuth2ForceConsent",
+                "display_name": "Force OAuth2 consent prompt:",
+                "type": "bool",
+                "help_text": "When true, users are always prompted for consent during OAuth2 authorization.",
+                "placeholder": "",
+                "default": true
             }
         ]
     }

--- a/plugin.json
+++ b/plugin.json
@@ -95,7 +95,7 @@
                 "key": "OAuth2ForceConsent",
                 "display_name": "Force OAuth2 consent prompt:",
                 "type": "bool",
-                "help_text": "When true, users are always prompted for consent during OAuth2 authorization.",
+                "help_text": "When true, users are always prompted for consent during OAuth2 authorization. Set to false if your Azure/Entra configuration requires admin consent for registered applications and non-admin users are encountering authorization errors.",
                 "placeholder": "",
                 "default": true
             }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR adds the ability for admins to opt out of having prompt=consent being added to the oauth connection URL

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-67945

#### QA Steps
In an environment that requires registered Azure applications to have admins grant permission for users to connect to an application (https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/configure-user-consent?pivots=portal#configure-user-consent-in-microsoft-entra-admin-center)

1. Install and setup MS Calendar on a fresh MM instance
2. Attempt to connect account with a non-admin user
3. Confirm whether the connection fails with a "OOO needs permission to access resources in your organization that only an admin can grant" when the setting is `true` and whether the connection succeeds when the setting is turned to `false`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Reasoning:** The PR changes the OAuth2 authorization URL construction—a security-sensitive, user-facing path—but preserves previous behavior by defaulting the new setting to true and adds targeted tests covering both consent states, reducing regression likelihood while still altering authentication-related control flow.

**Regression Risk:** Moderate. The change affects OAuth2 flow decisions based on two flags (plugin config and provider features), which can create multiple runtime permutations; however, unit tests were added to validate both forced-consent and non-forced-consent flows, and the default keeps existing behavior, limiting immediate breakage risk.

**QA Recommendation:** Manual QA recommended: verify connections in both configurations (OAuth2ForceConsent=true and false), and test provider-level ForceOAuth2Consent override. Specifically validate behavior with non-admin users in Azure/Entra setups requiring admin consent to ensure expected success/failure outcomes. Skipping manual QA is not advised due to the authentication blast radius.
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->