### PR TITLE
Adding dependabot config to batch changes into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+
+multi-ecosystem-groups:
+  all-dependencies:
+    schedule:
+      interval: "weekly"
+
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    patterns: ["*"]
+    multi-ecosystem-group: "all-dependencies"
+    open-pull-requests-limit: 1
+
+  - package-ecosystem: "npm"
+    directory: "/webapp"
+    patterns: ["*"]
+    multi-ecosystem-group: "all-dependencies"
+    open-pull-requests-limit: 1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,20 @@
 version: 2
 
-multi-ecosystem-groups:
-  all-dependencies:
-    schedule:
-      interval: "weekly"
-
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
-    patterns: ["*"]
-    multi-ecosystem-group: "all-dependencies"
+    schedule:
+      interval: "weekly"
     open-pull-requests-limit: 1
+    groups:
+      go-dependencies:
+        patterns: ["*"]
 
   - package-ecosystem: "npm"
     directory: "/webapp"
-    patterns: ["*"]
-    multi-ecosystem-group: "all-dependencies"
+    schedule:
+      interval: "weekly"
     open-pull-requests-limit: 1
+    groups:
+      webapp-dependencies:
+        patterns: ["*"]


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR adds some configuration to ensure dependabot only opens one PR at a time with all of the dependency updates it wants to do, this should both reduce the noise for reviews and increase the guarantee that all of the proposed updates still produce a working build as they'll go through CI together before hitting the master branch 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Reasoning:** This change is a CI/CD configuration addition that has no impact on application code, runtime behavior, or existing functionality. Dependabot configuration is purely infrastructure-level tooling that automates dependency updates without affecting the codebase's operational logic.

**Regression Risk:** Minimal. The change is isolated to configuration file addition (`.github/dependabot.yml`). No application code, shared utilities, base classes, or critical paths are affected. The configuration only determines how and when dependency updates are grouped in pull requests—it does not alter any existing behavior or introduce execution paths that could break functionality.

**QA Recommendation:** Manual QA is not required. This is a non-functional configuration change with zero impact on the product. Verification can be limited to confirming that future Dependabot PRs adhere to the configured grouping (one PR per ecosystem, weekly cadence) through observation of the next automated dependency update cycle.

*Generated by CodeRabbitAI*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost-plugin-mscalendar/pull/499?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->