### PR TITLE
MM-69074 Added nil guard on webhook handler

### DIFF
--- a/msgraph/handle_webhook.go
+++ b/msgraph/handle_webhook.go
@@ -67,6 +67,11 @@ func (r *impl) HandleWebhook(w http.ResponseWriter, req *http.Request) []*remote
 
 	notifications := []*remote.Notification{}
 	for _, wh := range v.Value {
+		if wh == nil {
+			r.logger.Infof("msgraph: skipping null webhook entry in notification payload.")
+			continue
+		}
+
 		n := &remote.Notification{
 			SubscriptionID: wh.SubscriptionID,
 			ChangeType:     wh.ChangeType,

--- a/msgraph/handle_webhook_test.go
+++ b/msgraph/handle_webhook_test.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package msgraph
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/config"
+	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/utils/bot"
+)
+
+func TestHandleWebhook(t *testing.T) {
+	remote := &impl{
+		conf:   &config.Config{},
+		logger: &bot.NilLogger{},
+	}
+
+	validWebhook := `{
+		"value": [{
+			"changeType": "updated",
+			"subscriptionId": "sub-123",
+			"subscriptionExpirationDateTime": "2030-01-01T00:00:00Z"
+		}]
+	}`
+
+	tests := []struct {
+		name                 string
+		body                 string
+		wantStatus           int
+		wantNotificationLen  int
+		wantSubscriptionID   string
+	}{
+		{
+			name:                "empty value array",
+			body:                `{"value":[]}`,
+			wantStatus:          http.StatusAccepted,
+			wantNotificationLen: 0,
+		},
+		{
+			name:                "null entry in value array",
+			body:                `{"value":[null]}`,
+			wantStatus:          http.StatusAccepted,
+			wantNotificationLen: 0,
+		},
+		{
+			name:                "mixed null and valid entries",
+			body:                `{"value":[null,{"changeType":"updated","subscriptionId":"sub-123","subscriptionExpirationDateTime":"2030-01-01T00:00:00Z"}]}`,
+			wantStatus:          http.StatusAccepted,
+			wantNotificationLen: 1,
+			wantSubscriptionID:  "sub-123",
+		},
+		{
+			name:                "valid webhook entry",
+			body:                validWebhook,
+			wantStatus:          http.StatusAccepted,
+			wantNotificationLen: 1,
+			wantSubscriptionID:  "sub-123",
+		},
+		{
+			name:                "invalid json",
+			body:                `{invalid`,
+			wantStatus:          http.StatusBadRequest,
+			wantNotificationLen: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/notification/v1/event", strings.NewReader(tc.body))
+			rec := httptest.NewRecorder()
+
+			require.NotPanics(t, func() {
+				notifications := remote.HandleWebhook(rec, req)
+				require.Len(t, notifications, tc.wantNotificationLen)
+				if tc.wantSubscriptionID != "" {
+					require.Equal(t, tc.wantSubscriptionID, notifications[0].SubscriptionID)
+				}
+			})
+
+			require.Equal(t, tc.wantStatus, rec.Result().StatusCode)
+		})
+	}
+}
+
+func TestHandleWebhookValidationToken(t *testing.T) {
+	remote := &impl{
+		conf:   &config.Config{},
+		logger: &bot.NilLogger{},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/notification/v1/event?validationToken=test-token", nil)
+	rec := httptest.NewRecorder()
+
+	notifications := remote.HandleWebhook(rec, req)
+
+	require.Nil(t, notifications)
+	require.Equal(t, http.StatusOK, rec.Result().StatusCode)
+	require.Equal(t, "test-token", rec.Body.String())
+}

--- a/msgraph/handle_webhook_test.go
+++ b/msgraph/handle_webhook_test.go
@@ -30,11 +30,11 @@ func TestHandleWebhook(t *testing.T) {
 	}`
 
 	tests := []struct {
-		name                 string
-		body                 string
-		wantStatus           int
-		wantNotificationLen  int
-		wantSubscriptionID   string
+		name                string
+		body                string
+		wantStatus          int
+		wantNotificationLen int
+		wantSubscriptionID  string
 	}{
 		{
 			name:                "empty value array",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR adds a nil guard when processing webhooks to ensure no runtime errors happen

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://mattermost.atlassian.net/browse/MM-69074

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Reasoning:** This PR adds a nil safety guard to webhook processing with comprehensive test coverage. The change is defensive in nature—it prevents runtime nil pointer dereferences without altering existing functionality. The fix is isolated to the msgraph module's webhook handler with no public API modifications.

**Regression Risk:** Very low. The nil guard is additive (skips over nil entries with logging) rather than modifying existing control flow. New tests (105 lines) cover normal cases, edge cases (empty arrays, null entries), invalid JSON, and validation token scenarios, ensuring the handler behaves correctly under various conditions. No shared utilities or widely-imported modules are affected.

**QA Recommendation:** Minimal manual QA required. The change is straightforward—add nil entry protection and skip them gracefully. Verify that webhook processing continues normally when encountering nil entries and that logging appropriately records these skip events. Standard regression testing of webhook notification flows is sufficient; no special edge case testing is needed given the comprehensive automated test coverage.
*Generated by CodeRabbitAI*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost-plugin-mscalendar/pull/501?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->