### PR TITLE
Making dependabot guardrails more strict

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
     groups:
       go-dependencies:
         patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directory: "/webapp"
@@ -18,3 +21,12 @@ updates:
     groups:
       webapp-dependencies:
         patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+      # Pinned: React/Bootstrap upgrades require coordinated webapp changes
+      - dependency-name: "react"
+      - dependency-name: "react-dom"
+      - dependency-name: "@types/react"
+      - dependency-name: "@types/react-dom"
+      - dependency-name: "react-bootstrap"


### PR DESCRIPTION

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR adds some extra limitations on dependabot PRs as some changes are best done manually
- Disallowing automatic upgrades of major dependency versions
- Preventing arbitrary upgrades of react / react-dom / react-bootstrap

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Reasoning:** This is a CI/CD configuration change to Dependabot rules that restricts automatic dependency upgrades for major versions. It does not affect application code, runtime behavior, or any critical paths, and serves as a safeguard rather than introducing new functionality or risk.

**Regression Risk:** Negligible. The change only modifies Dependabot's behavior for creating pull requests; it does not affect application code execution, existing tests, or any runtime logic. No shared dependencies or critical business flows are impacted. The configuration prevents rather than introduces automated changes.

**QA Recommendation:** Minimal manual QA required. Verification can be limited to confirming that Dependabot respects the new ignore rules by checking that no new major version upgrade PRs are automatically created for the specified dependencies (react, react-dom, and related packages) and all gomod packages. No production testing or integration testing is needed as this is purely an operational policy change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->