### PR TITLE
MM-69074 Added nil guard on webhook handler (#501)

### DIFF
--- a/msgraph/handle_webhook.go
+++ b/msgraph/handle_webhook.go
@@ -67,6 +67,11 @@ func (r *impl) HandleWebhook(w http.ResponseWriter, req *http.Request) []*remote
 
 	notifications := []*remote.Notification{}
 	for _, wh := range v.Value {
+		if wh == nil {
+			r.logger.Infof("msgraph: skipping null webhook entry in notification payload.")
+			continue
+		}
+
 		n := &remote.Notification{
 			SubscriptionID: wh.SubscriptionID,
 			ChangeType:     wh.ChangeType,

--- a/msgraph/handle_webhook_test.go
+++ b/msgraph/handle_webhook_test.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package msgraph
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/config"
+	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/utils/bot"
+)
+
+func TestHandleWebhook(t *testing.T) {
+	remote := &impl{
+		conf:   &config.Config{},
+		logger: &bot.NilLogger{},
+	}
+
+	validWebhook := `{
+		"value": [{
+			"changeType": "updated",
+			"subscriptionId": "sub-123",
+			"subscriptionExpirationDateTime": "2030-01-01T00:00:00Z"
+		}]
+	}`
+
+	tests := []struct {
+		name                string
+		body                string
+		wantStatus          int
+		wantNotificationLen int
+		wantSubscriptionID  string
+	}{
+		{
+			name:                "empty value array",
+			body:                `{"value":[]}`,
+			wantStatus:          http.StatusAccepted,
+			wantNotificationLen: 0,
+		},
+		{
+			name:                "null entry in value array",
+			body:                `{"value":[null]}`,
+			wantStatus:          http.StatusAccepted,
+			wantNotificationLen: 0,
+		},
+		{
+			name:                "mixed null and valid entries",
+			body:                `{"value":[null,{"changeType":"updated","subscriptionId":"sub-123","subscriptionExpirationDateTime":"2030-01-01T00:00:00Z"}]}`,
+			wantStatus:          http.StatusAccepted,
+			wantNotificationLen: 1,
+			wantSubscriptionID:  "sub-123",
+		},
+		{
+			name:                "valid webhook entry",
+			body:                validWebhook,
+			wantStatus:          http.StatusAccepted,
+			wantNotificationLen: 1,
+			wantSubscriptionID:  "sub-123",
+		},
+		{
+			name:                "invalid json",
+			body:                `{invalid`,
+			wantStatus:          http.StatusBadRequest,
+			wantNotificationLen: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/notification/v1/event", strings.NewReader(tc.body))
+			rec := httptest.NewRecorder()
+
+			require.NotPanics(t, func() {
+				notifications := remote.HandleWebhook(rec, req)
+				require.Len(t, notifications, tc.wantNotificationLen)
+				if tc.wantSubscriptionID != "" {
+					require.Equal(t, tc.wantSubscriptionID, notifications[0].SubscriptionID)
+				}
+			})
+
+			require.Equal(t, tc.wantStatus, rec.Result().StatusCode)
+		})
+	}
+}
+
+func TestHandleWebhookValidationToken(t *testing.T) {
+	remote := &impl{
+		conf:   &config.Config{},
+		logger: &bot.NilLogger{},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/notification/v1/event?validationToken=test-token", nil)
+	rec := httptest.NewRecorder()
+
+	notifications := remote.HandleWebhook(rec, req)
+
+	require.Nil(t, notifications)
+	require.Equal(t, http.StatusOK, rec.Result().StatusCode)
+	require.Equal(t, "test-token", rec.Body.String())
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:
1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Cherry-pick PR of #501 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Reasoning:** This is a defensive nil guard addition to the webhook handler that prevents potential nil pointer dereferences when Microsoft Graph sends null entries in webhook payloads. The change is isolated to a single function and does not modify behavior for valid inputs. Comprehensive test coverage covering null entries, mixed payloads, and validation flows significantly reduces regression risk.

**Regression Risk:** Very low. The nil guard only adds defensive logic to skip malformed entries and log them—behavior that previously would have caused a panic. Valid webhook entries are processed identically to before. The change touches no shared dependencies, public APIs, or critical business logic flows. It's a cherry-pick of an already-reviewed PR `#501`.

**QA Recommendation:** Minimal manual QA required. The new test suite comprehensively covers the added nil-guard behavior, validation token handling, and edge cases (empty arrays, mixed null/valid entries, invalid JSON). Focus QA on integration testing the webhook endpoint with malformed payloads from Microsoft Graph to ensure graceful handling in production and that null entries don't block processing of subsequent valid entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->