### PR TITLE
MM-69393 Improving processing of requests

### DIFF
--- a/calendar/api/post_action.go
+++ b/calendar/api/post_action.go
@@ -180,14 +180,13 @@ func (api *api) postActionConfirmStatusChange(w http.ResponseWriter, req *http.R
 			utils.SlackAttachmentError(w, "Error: invalid state to change to.")
 			return
 		}
-		prettyChangeTo, ok := request.Context["pretty_change_to"]
-		if !ok {
-			prettyChangeTo = changeTo
-		}
-		stringPrettyChangeTo, ok := prettyChangeTo.(string)
-		if !ok {
-			utils.SlackAttachmentError(w, "Error: invalid pretty state to change to.")
-			return
+		stringPrettyChangeTo := stringChangeTo
+		if prettyChangeTo, ok := request.Context["pretty_change_to"]; ok {
+			stringPrettyChangeTo, ok = prettyChangeTo.(string)
+			if !ok {
+				utils.SlackAttachmentError(w, "Error: invalid pretty state to change to.")
+				return
+			}
 		}
 
 		status, err := api.PluginAPI.GetMattermostUserStatus(mattermostUserID)

--- a/calendar/api/post_action.go
+++ b/calendar/api/post_action.go
@@ -175,12 +175,20 @@ func (api *api) postActionConfirmStatusChange(w http.ResponseWriter, req *http.R
 			utils.SlackAttachmentError(w, "No state to change to.")
 			return
 		}
-		stringChangeTo := changeTo.(string)
+		stringChangeTo, ok := changeTo.(string)
+		if !ok {
+			utils.SlackAttachmentError(w, "Error: invalid state to change to.")
+			return
+		}
 		prettyChangeTo, ok := request.Context["pretty_change_to"]
 		if !ok {
 			prettyChangeTo = changeTo
 		}
-		stringPrettyChangeTo := prettyChangeTo.(string)
+		stringPrettyChangeTo, ok := prettyChangeTo.(string)
+		if !ok {
+			utils.SlackAttachmentError(w, "Error: invalid pretty state to change to.")
+			return
+		}
 
 		status, err := api.PluginAPI.GetMattermostUserStatus(mattermostUserID)
 		if err != nil {

--- a/calendar/api/post_action_test.go
+++ b/calendar/api/post_action_test.go
@@ -502,6 +502,49 @@ func TestPostActionConfirmStatusChange(t *testing.T) {
 			},
 		},
 		{
+			name: "Numeric change_to does not panic",
+			setup: func(req *http.Request) {
+				req.Header.Set(MMUserIDHeader, MockUserID)
+				requestBody := model.PostActionIntegrationRequest{
+					Context: map[string]interface{}{
+						"value":     true,
+						"change_to": 123,
+					},
+				}
+				bodyBytes, _ := json.Marshal(requestBody)
+				req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+			},
+			assertions: func(rec *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusOK, rec.Result().StatusCode)
+				var response model.PostActionIntegrationResponse
+				err := json.NewDecoder(rec.Body).Decode(&response)
+				assert.NoError(t, err)
+				assert.Contains(t, response.EphemeralText, "Error: invalid state to change to.")
+			},
+		},
+		{
+			name: "Numeric pretty_change_to does not panic",
+			setup: func(req *http.Request) {
+				req.Header.Set(MMUserIDHeader, MockUserID)
+				requestBody := model.PostActionIntegrationRequest{
+					Context: map[string]interface{}{
+						"value":            true,
+						"change_to":        "away",
+						"pretty_change_to": 123,
+					},
+				}
+				bodyBytes, _ := json.Marshal(requestBody)
+				req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+			},
+			assertions: func(rec *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusOK, rec.Result().StatusCode)
+				var response model.PostActionIntegrationResponse
+				err := json.NewDecoder(rec.Body).Decode(&response)
+				assert.NoError(t, err)
+				assert.Contains(t, response.EphemeralText, "Error: invalid pretty state to change to.")
+			},
+		},
+		{
 			name: "Error getting user status",
 			setup: func(req *http.Request) {
 				mockPluginAPI.EXPECT().GetMattermostUserStatus(MockUserID).Return(nil, errors.New("status error")).Times(1)

--- a/calendar/plugin/plugin.go
+++ b/calendar/plugin/plugin.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"text/template"
@@ -290,6 +291,17 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 }
 
 func (p *Plugin) ServeHTTP(_ *plugin.Context, w http.ResponseWriter, req *http.Request) {
+	defer func() {
+		if r := recover(); r != nil {
+			p.API.LogError("Recovered from panic while serving HTTP request",
+				"url", req.URL.String(),
+				"error", fmt.Sprintf("%v", r),
+				"stack", string(debug.Stack()),
+			)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
+	}()
+
 	env := p.getEnv()
 	if env.configError != nil {
 		p.API.LogError("Error occurred while getting env", "err", env.configError.Error())

--- a/calendar/plugin/plugin_test.go
+++ b/calendar/plugin/plugin_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package plugin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/utils/httputils"
+)
+
+func TestServeHTTPRecoversFromPanic(t *testing.T) {
+	mockAPI := &plugintest.API{}
+	mockAPI.On("LogError", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	defer mockAPI.AssertExpectations(t)
+
+	handler := httputils.NewHandler()
+	handler.Router.HandleFunc("/panic", func(http.ResponseWriter, *http.Request) {
+		panic("boom")
+	}).Methods(http.MethodGet)
+
+	p := &Plugin{envLock: &sync.RWMutex{}}
+	p.SetAPI(mockAPI)
+	p.env = Env{httpHandler: handler}
+
+	req := httptest.NewRequest(http.MethodGet, "/panic", nil)
+	rec := httptest.NewRecorder()
+
+	assert.NotPanics(t, func() {
+		p.ServeHTTP(nil, rec, req)
+	})
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Result().StatusCode)
+	mockAPI.AssertCalled(t, "LogError", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestServeHTTPNoPanicSucceeds(t *testing.T) {
+	handler := httputils.NewHandler()
+	handler.Router.HandleFunc("/ok", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}).Methods(http.MethodGet)
+
+	p := &Plugin{envLock: &sync.RWMutex{}}
+	p.env = Env{httpHandler: handler}
+
+	req := httptest.NewRequest(http.MethodGet, "/ok", nil)
+	rec := httptest.NewRecorder()
+
+	p.ServeHTTP(nil, rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Result().StatusCode)
+}

--- a/calendar/plugin/plugin_test.go
+++ b/calendar/plugin/plugin_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestServeHTTPRecoversFromPanic(t *testing.T) {
 	mockAPI := &plugintest.API{}
-	mockAPI.On("LogError", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	mockAPI.On("LogError", "Recovered from panic while serving HTTP request", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	defer mockAPI.AssertExpectations(t)
 
 	handler := httputils.NewHandler()
@@ -38,7 +38,6 @@ func TestServeHTTPRecoversFromPanic(t *testing.T) {
 	})
 
 	assert.Equal(t, http.StatusInternalServerError, rec.Result().StatusCode)
-	mockAPI.AssertCalled(t, "LogError", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestServeHTTPNoPanicSucceeds(t *testing.T) {

--- a/calendar/utils/settingspanel/handler.go
+++ b/calendar/utils/settingspanel/handler.go
@@ -59,7 +59,11 @@ func (sh *handler) handleAction(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	idString := id.(string)
+	idString, ok := id.(string)
+	if !ok {
+		utils.SlackAttachmentError(w, "Error: invalid setting id")
+		return
+	}
 	err := sh.panel.Set(mattermostUserID, idString, value)
 	if err != nil {
 		utils.SlackAttachmentError(w, "Error: cannot set the property, "+err.Error())

--- a/calendar/utils/settingspanel/handler_test.go
+++ b/calendar/utils/settingspanel/handler_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package settingspanel
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mattermost/mattermost/server/public/model"
+
+	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/utils/httputils"
+)
+
+const settingsURL = "/settings"
+
+type stubPanel struct {
+	setCalled bool
+}
+
+func (p *stubPanel) Set(userID, settingID string, value interface{}) error {
+	p.setCalled = true
+	return nil
+}
+func (p *stubPanel) Print(userID string)                       {}
+func (p *stubPanel) ToPost(userID string) (*model.Post, error) { return &model.Post{}, nil }
+func (p *stubPanel) Clear(userID string) error                 { return nil }
+func (p *stubPanel) URL() string                               { return settingsURL }
+func (p *stubPanel) GetSettingIDs() []string                   { return nil }
+
+func TestHandleActionInvalidSettingID(t *testing.T) {
+	panel := &stubPanel{}
+	handler := httputils.NewHandler()
+	Init(handler, panel)
+
+	requestBody := model.PostActionIntegrationRequest{
+		Context: map[string]interface{}{
+			ContextIDKey:          123,
+			ContextButtonValueKey: "on",
+		},
+	}
+	bodyBytes, _ := json.Marshal(requestBody)
+
+	req := httptest.NewRequest(http.MethodPost, settingsURL, io.NopCloser(bytes.NewBuffer(bodyBytes)))
+	req.Header.Set("Mattermost-User-Id", "mockUserID")
+	rec := httptest.NewRecorder()
+
+	assert.NotPanics(t, func() {
+		handler.ServeHTTP(rec, req)
+	})
+
+	assert.Equal(t, http.StatusOK, rec.Result().StatusCode)
+	var response model.PostActionIntegrationResponse
+	err := json.NewDecoder(rec.Body).Decode(&response)
+	assert.NoError(t, err)
+	assert.Contains(t, response.EphemeralText, "Error: invalid setting id")
+	assert.False(t, panel.setCalled, "panel.Set should not be called for an invalid setting id")
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR makes some general improvements on how requests are processed and adds logging in cases of errors 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://mattermost.atlassian.net/browse/MM-69393

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Reasoning:** The PR strengthens request-processing robustness by replacing unsafe type assertions with validated parsing and adding panic recovery in the plugin HTTP entrypoint. While this improves reliability and adds targeted tests for invalid numeric payloads and panic recovery, it changes edge-case behavior across multiple user-facing handlers.

**Regression Risk:** Moderate. Behavior changes occur in previously-assumed-valid context/payload shapes, and the HTTP-layer recovery affects the global request flow, though core business logic is not modified.

**QA Recommendation:** Moderate manual QA is recommended: verify the post-action and settings panel endpoints with malformed/invalid `change_to`, `pretty_change_to`, and context IDs; also confirm plugin panic recovery returns `500` and logs appropriately. Automated tests should cover the main cases, but manual spot checks are advisable due to edge-case contract changes.
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->