### PR TITLE
MM-69738 Fix issue with create button disabling on date change

### DIFF
--- a/webapp/src/components/channel_selector.tsx
+++ b/webapp/src/components/channel_selector.tsx
@@ -106,6 +106,7 @@ export default function ChannelSelector(props: Props) {
                 onChange={handleChange}
                 styles={getStyleForReactSelect(theme)}
                 isMulti={false}
+                isClearable={true}
             />
             {storedError && (
                 <div role='alert'>

--- a/webapp/src/components/modals/create_event_form.tsx
+++ b/webapp/src/components/modals/create_event_form.tsx
@@ -26,7 +26,7 @@ import DateInput from '@/components/date_input';
 import {capitalizeFirstCharacter} from '@/utils/text';
 import {useAppDispatch} from '@/hooks';
 import {createCalendarEvent, refreshActiveCalendarView} from '@/actions';
-import {getTodayString} from '@/utils/datetime';
+import {getEarliestTimeForToday, getTodayString} from '@/utils/datetime';
 import {getCreateEventModal} from '@/selectors';
 
 import './create_event_form.scss';
@@ -224,8 +224,17 @@ const ActualForm = (props: ActualFormProps) => {
                     min={getTodayString()}
                     onChange={(value) => {
                         setFormValue('date', value);
-                        setFormValue('start_time', '');
-                        setFormValue('end_time', '');
+
+                        // Only clear the times when they become invalid for the new
+                        // date (i.e. now in the past when switching to today), so the
+                        // form stays submittable after simply changing the date.
+                        const startInPast = value === getTodayString() &&
+                            formValues.start_time !== '' &&
+                            formValues.start_time < getEarliestTimeForToday();
+                        if (startInPast) {
+                            setFormValue('start_time', '');
+                            setFormValue('end_time', '');
+                        }
                     }}
                     className='form-control'
                 />

--- a/webapp/src/components/time_selector.tsx
+++ b/webapp/src/components/time_selector.tsx
@@ -3,12 +3,10 @@ import {useSelector} from 'react-redux';
 
 import {getTheme} from 'mattermost-redux/selectors/entities/preferences';
 
-import {getTodayString} from '@/utils/datetime';
+import {MINUTE_STEP, getTodayString} from '@/utils/datetime';
 import {CreateEventPayload} from '@/types/calendar_api_types';
 
 import ReactSelectSetting from './react_select_setting';
-
-const minuteStep = 15;
 
 type Props = {
     inputId?: string;
@@ -42,7 +40,7 @@ export default function TimeSelector(props: Props) {
         if (props.date === getTodayString()) {
             constrainedByDate = true;
             const now = new Date();
-            const roundedMinutes = Math.ceil(now.getMinutes() / minuteStep) * minuteStep;
+            const roundedMinutes = Math.ceil(now.getMinutes() / MINUTE_STEP) * MINUTE_STEP;
             fromHour = now.getHours() + Math.floor(roundedMinutes / 60);
             fromMinute = roundedMinutes % 60;
             ranges = generateMilitaryTimeArray(fromHour, fromMinute, toHour, toMinute);
@@ -51,7 +49,7 @@ export default function TimeSelector(props: Props) {
         if (props.startTime) {
             const parsed = parseHHMM(props.startTime);
             fromHour = parsed.hour;
-            fromMinute = parsed.minute + minuteStep;
+            fromMinute = parsed.minute + MINUTE_STEP;
             const extraHours = Math.floor(fromMinute / 60);
             fromMinute %= 60;
             fromHour += extraHours;
@@ -66,7 +64,7 @@ export default function TimeSelector(props: Props) {
             toMinute = parsed.minute;
             if (isStartTimeSelector) {
                 const endTotal = (toHour * 60) + toMinute;
-                const maxStartTotal = endTotal - minuteStep;
+                const maxStartTotal = endTotal - MINUTE_STEP;
                 if (maxStartTotal < 0) {
                     return [];
                 }
@@ -128,7 +126,7 @@ const parseHHMM = (time: string): {hour: number; minute: number} => {
     };
 };
 
-const generateMilitaryTimeArray = (fromHour = 0, fromMinute = 0, toHour = 23, toMinute = 45, step = minuteStep) => {
+const generateMilitaryTimeArray = (fromHour = 0, fromMinute = 0, toHour = 23, toMinute = 45, step = MINUTE_STEP) => {
     const timeArray = [];
     for (let hour = fromHour; hour <= toHour; hour++) {
         const startMinute = hour === fromHour ? fromMinute : 0;

--- a/webapp/src/utils/datetime.test.ts
+++ b/webapp/src/utils/datetime.test.ts
@@ -1,0 +1,39 @@
+import {getEarliestTimeForToday} from './datetime';
+
+describe('getEarliestTimeForToday', () => {
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    const setNow = (hours: number, minutes: number) => {
+        jest.useFakeTimers();
+        const now = new Date();
+        now.setHours(hours, minutes, 0, 0);
+        jest.setSystemTime(now);
+    };
+
+    it('rounds up to the next 15-minute step', () => {
+        setNow(9, 1);
+        expect(getEarliestTimeForToday()).toBe('09:15');
+    });
+
+    it('keeps the time when already on a step boundary', () => {
+        setNow(9, 30);
+        expect(getEarliestTimeForToday()).toBe('09:30');
+    });
+
+    it('rolls the hour over when rounding crosses the hour', () => {
+        setNow(9, 46);
+        expect(getEarliestTimeForToday()).toBe('10:00');
+    });
+
+    it('clamps to 23:45 when rounding pushes past the end of the day', () => {
+        setNow(23, 46);
+        expect(getEarliestTimeForToday()).toBe('23:45');
+    });
+
+    it('clamps to 23:45 at exactly 23:45', () => {
+        setNow(23, 45);
+        expect(getEarliestTimeForToday()).toBe('23:45');
+    });
+});

--- a/webapp/src/utils/datetime.ts
+++ b/webapp/src/utils/datetime.ts
@@ -1,4 +1,7 @@
-const MINUTE_STEP = 15;
+export const MINUTE_STEP = 15;
+
+// Latest selectable time in the day, matching the option constraints in TimeSelector.
+const LATEST_TIME = '23:45';
 
 export function getTodayString(): string {
     const now = new Date();
@@ -15,5 +18,13 @@ export function getEarliestTimeForToday(): string {
     const roundedMinutes = Math.ceil(now.getMinutes() / MINUTE_STEP) * MINUTE_STEP;
     const hour = now.getHours() + Math.floor(roundedMinutes / 60);
     const minute = roundedMinutes % 60;
+
+    // When rounding pushes past the end of the day (e.g. now >= 23:45), clamp to
+    // the latest selectable time so lex comparisons don't treat every start time
+    // as being in the past.
+    if (hour >= 24) {
+        return LATEST_TIME;
+    }
+
     return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
 }

--- a/webapp/src/utils/datetime.ts
+++ b/webapp/src/utils/datetime.ts
@@ -1,7 +1,19 @@
+const MINUTE_STEP = 15;
+
 export function getTodayString(): string {
     const now = new Date();
     const year = now.getFullYear();
     const month = String(now.getMonth() + 1).padStart(2, '0');
     const day = String(now.getDate()).padStart(2, '0');
     return `${year}-${month}-${day}`;
+}
+
+// Earliest selectable time for today, rounded up to the next MINUTE_STEP.
+// Kept consistent with the option constraints in TimeSelector.
+export function getEarliestTimeForToday(): string {
+    const now = new Date();
+    const roundedMinutes = Math.ceil(now.getMinutes() / MINUTE_STEP) * MINUTE_STEP;
+    const hour = now.getHours() + Math.floor(roundedMinutes / 60);
+    const minute = roundedMinutes % 60;
+    return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR addresses an issue with the create event modal's "Create" button being disabled when a date value changes

This PR also fixes an issue with the linked channel field not being able to be cleared, included in this PR as it was a one-line fix

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://mattermost.atlassian.net/browse/MM-69738
Fixes https://mattermost.atlassian.net/browse/MM-69739
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Reasoning:** The change adjusts user-facing create-event form validation logic and adds a new datetime helper that’s used by shared time/date constraints (including rounding to a 15-minute step). It also updates the channel selector UX to allow clearing, which impacts the submission payload and validation state.

**Regression Risk:** Medium; while the datetime utility change is targeted and accompanied by unit tests for the new “earliest time today” behavior, it can still affect edge cases around “today” boundaries and time clearing/ordering that determine whether the Create button is enabled.

**QA Recommendation:** Do focused manual QA (moderate amount): create events switching to/from today, changing the date while start/end times are set (especially around the earliest selectable time thresholds), verifying Create button enable/disable, and clearing the linked channel to confirm the submitted value is empty and validation still succeeds. Skipping manual QA carries moderate risk.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->