### PR TITLE
Fix time-of-day dependent createEvent test failures

### DIFF
--- a/calendar/api/events_test.go
+++ b/calendar/api/events_test.go
@@ -159,8 +159,8 @@ func TestIsValid(t *testing.T) {
 		{
 			name: "Invalid end time",
 			payload: func() createEventPayload {
-				futureTime := time.Now().UTC().Add(24 * time.Hour)
-				return GetMockCreateEventPayload(false, nil, futureTime.Format("2006-01-02"), futureTime.Add(1*time.Hour).Format("15:04"), "invalidEndTime", "mockDescription", "mockSubject", "mockLocation", "")
+				futureTime := TomorrowMidnightUTC()
+				return GetMockCreateEventPayload(false, nil, futureTime.Format("2006-01-02"), futureTime.Add(10*time.Hour).Format("15:04"), "invalidEndTime", "mockDescription", "mockSubject", "mockLocation", "")
 			}(),
 			assertions: func(t *testing.T, err error) {
 				assert.ErrorContains(t, err, "please use a valid end time")
@@ -169,8 +169,8 @@ func TestIsValid(t *testing.T) {
 		{
 			name: "End time before start time",
 			payload: func() createEventPayload {
-				futureTime := time.Now().UTC().Add(24 * time.Hour)
-				return GetMockCreateEventPayload(false, nil, futureTime.Format("2006-01-02"), futureTime.Add(2*time.Hour).Format("15:04"), futureTime.Add(1*time.Hour).Format("15:04"), "mockDescription", "mockSubject", "mockLocation", "")
+				futureTime := TomorrowMidnightUTC()
+				return GetMockCreateEventPayload(false, nil, futureTime.Format("2006-01-02"), futureTime.Add(12*time.Hour).Format("15:04"), futureTime.Add(10*time.Hour).Format("15:04"), "mockDescription", "mockSubject", "mockLocation", "")
 			}(),
 			assertions: func(t *testing.T, err error) {
 				assert.ErrorContains(t, err, "end date cannot be earlier than start date")
@@ -179,8 +179,8 @@ func TestIsValid(t *testing.T) {
 		{
 			name: "Valid event",
 			payload: func() createEventPayload {
-				futureTime := time.Now().UTC().Add(24 * time.Hour)
-				return GetMockCreateEventPayload(false, nil, futureTime.Format("2006-01-02"), futureTime.Add(1*time.Hour).Format("15:04"), futureTime.Add(2*time.Hour).Format("15:04"), "mockDescription", "mockSubject", "mockLocation", "")
+				futureTime := TomorrowMidnightUTC()
+				return GetMockCreateEventPayload(false, nil, futureTime.Format("2006-01-02"), futureTime.Add(10*time.Hour).Format("15:04"), futureTime.Add(12*time.Hour).Format("15:04"), "mockDescription", "mockSubject", "mockLocation", "")
 			}(),
 			assertions: func(t *testing.T, err error) {
 				assert.NoError(t, err)

--- a/calendar/api/test_utils.go
+++ b/calendar/api/test_utils.go
@@ -105,11 +105,11 @@ func GetMockCreateEventPayload(allDay bool, attendees []string, date, startTime,
 }
 
 func GetCurrentTimeRequestBodyJSON(channelID string) string {
-	// Use UTC to match test mailbox timezone and add extra buffer to avoid edge cases
-	currentTime := time.Now().UTC().Add(24 * time.Hour)
-	date := currentTime.Format("2006-01-02")
-	startTime := currentTime.Add(time.Hour).Format("15:04")
-	endTime := currentTime.Add(2 * time.Hour).Format("15:04")
+	// Use UTC to match test mailbox timezone
+	tomorrow := TomorrowMidnightUTC()
+	date := tomorrow.Format("2006-01-02")
+	startTime := tomorrow.Add(10 * time.Hour).Format("15:04")
+	endTime := tomorrow.Add(12 * time.Hour).Format("15:04")
 
 	return fmt.Sprintf(`{
 					"all_day": false,
@@ -122,6 +122,12 @@ func GetCurrentTimeRequestBodyJSON(channelID string) string {
 					"location": "Conference Room",
 					"channel_id": "%s"
 				}`, date, startTime, endTime, channelID)
+}
+
+// TomorrowMidnightUTC anchors event fixtures to a fixed time of day so that
+// start/end offsets never roll over into the following day.
+func TomorrowMidnightUTC() time.Time {
+	return time.Now().UTC().Add(24 * time.Hour).Truncate(24 * time.Hour)
 }
 
 func GetMockRemoteEvent() *remote.Event {


### PR DESCRIPTION
#### Summary

`calendar/api` tests fail deterministically for any CI run between roughly 22:00 and 00:00 UTC, which is why unrelated dependabot PRs (e.g. #528, #531) have been going red.

The event fixtures derived the date from `now + 24h` but the start and end times from `now + 25h` and `now + 26h`, then pasted those times onto the earlier date. Once the UTC hour reaches 22, the end time rolls over midnight, producing e.g. `date 2026-08-11, start 23:13, end 00:13`. `createEventPayload.IsValid` then rejects the payload with "end date cannot be earlier than start date", which breaks `TestIsValid/Valid_event`, inverts `TestIsValid/End_time_before_start_time`, and makes all six `TestCreateEvent` subtests bail out on unexpected `createEvent, invalid payload` logging.

Fixtures are now anchored to tomorrow's midnight UTC with fixed 10:00/12:00 offsets, so the start and end times can never roll into the following day.

Verified the start-after-now and end-after-start invariants hold for all 1440 minutes of the day, including in `America/New_York` which `TestIsValid` uses.

#### Release Note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Reasoning:** The changes are isolated to calendar test fixtures and test utilities. They do not affect production logic, data, authentication, or user-facing behavior.

**Regression Risk:** Low. The shared helper is limited to test code, and the updated timestamps reduce time-dependent test failures.

**QA Recommendation:** Manual QA is not required. Automated test validation is sufficient. Skipping manual QA has low risk.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->